### PR TITLE
Add config for running on circle ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stackdriver Debugger PHP Extension
+# Stackdriver Debugger PHP Extension [![CircleCI](https://circleci.com/gh/GoogleCloudPlatform/stackdriver-debugger-php-extension.svg?style=svg)](https://circleci.com/gh/GoogleCloudPlatform/stackdriver-debugger-php-extension)
 
 Stackdriver Debugger is a free, open-source way to debug your running
 application without requiring a redeployment.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+machine:
+  timezone: America/Los_Angeles
+  environment:
+    GCLOUD_DIR: ${HOME}/gcloud
+    PATH: ${GCLOUD_DIR}/google-cloud-sdk/bin:${PATH}
+    CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+    CLOUDSDK_ACTIVE_CONFIG_NAME: opencensus-php
+    TEST_BUILD_DIR: ${HOME}
+    PHP_DOCKER_GOOGLE_CREDENTIALS: ${HOME}/credentials.json
+    GOOGLE_PROJECT_ID: php-stackdriver
+    TAG: circle-${CIRCLE_BUILD_NUM}
+
+dependencies:
+  override:
+    - scripts/install_test_dependencies.sh
+
+test:
+  override:
+    - scripts/run_test_suite.sh

--- a/scripts/dump_credentials.php
+++ b/scripts/dump_credentials.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Dumps the contents of the environment variable GOOGLE_CREDENTIALS_BASE64 to
+ * a file.
+ *
+ * To setup Travis to run on your fork, read TRAVIS.md.
+ */
+if (getenv('GOOGLE_CREDENTIALS_BASE64') === false) {
+    exit(0);
+}
+file_put_contents(
+    getenv('PHP_DOCKER_GOOGLE_CREDENTIALS'),
+    base64_decode(getenv('GOOGLE_CREDENTIALS_BASE64'))
+);

--- a/scripts/install_test_dependencies.sh
+++ b/scripts/install_test_dependencies.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script for installing necessary software on CI systems.
+
+set -ex
+
+if [ "${INSTALL_GCLOUD}" == "true" ]; then
+    # Install gcloud
+    if [ ! -d ${HOME}/gcloud/google-cloud-sdk ]; then
+        mkdir -p ${HOME}/gcloud &&
+        wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz --directory-prefix=${HOME}/gcloud &&
+        cd "${HOME}/gcloud" &&
+            tar xzf google-cloud-sdk.tar.gz &&
+            ./google-cloud-sdk/install.sh --usage-reporting false --path-update false --command-completion false &&
+            cd "${TEST_BUILD_DIR}";
+    fi
+fi
+
+if [ -z "${CLOUDSDK_ACTIVE_CONFIG_NAME}" ]; then
+    echo "You need to set CLOUDSDK_ACTIVE_CONFIG_NAME envvar."
+    exit 1
+fi
+
+if [ -z "${GOOGLE_PROJECT_ID}" ]; then
+    echo "You need to set GOOGLE_PROJECT_ID envvar."
+    exit 1
+fi
+
+if [ -z "${CLOUDSDK_VERBOSITY}" ]; then
+    CLOUDSDK_VERBOSITY='none'
+fi
+
+# gcloud configurations
+gcloud config configurations create ${CLOUDSDK_ACTIVE_CONFIG_NAME} || /bin/true # ignore failure
+gcloud config set project ${GOOGLE_PROJECT_ID}
+gcloud config set app/promote_by_default false
+gcloud config set verbosity ${CLOUDSDK_VERBOSITY}
+
+# Dump the credentials from the environment variable.
+php scripts/dump_credentials.php
+
+# Set the timeout
+gcloud config set container/build_timeout 3600
+
+if [ ! -f "${PHP_DOCKER_GOOGLE_CREDENTIALS}" ]; then
+    echo 'Please set PHP_DOCKER_GOOGLE_CREDENTIALS envvar.'
+    exit 1
+fi
+
+# Use the service account for gcloud operations.
+gcloud auth activate-service-account \
+    --key-file "${PHP_DOCKER_GOOGLE_CREDENTIALS}"
+
+if [ "${CIRCLECI}" == "true" ]; then
+    # Need sudo on circleci:
+    # https://discuss.circleci.com/t/gcloud-components-update-version-restriction/3725
+    # They also overrides the PATH to use
+    # /opt/google-cloud-sdk/bin/gcloud so we can not easily use our
+    # own gcloud
+    sudo /opt/google-cloud-sdk/bin/gcloud -q components update beta
+else
+    gcloud -q components update beta
+fi

--- a/scripts/run_test_suite.sh
+++ b/scripts/run_test_suite.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script for installing necessary software on CI systems.
+
+set -ex
+
+gcloud container builds submit --config=cloudbuild.yaml .


### PR DESCRIPTION
Enabling CI via CircleCI.

Compiles extension and runs tests against PHP 7.0, 7.1, and 7.2 via a container builder job.