### PR TITLE
Callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ function:
  *            in the execution context that are captured along with the local
  *            variables in scope.
  *      @type string $currentFile
+ *      @type callable $callable
  * }
  */
 function stackdriver_debugger_add_snapshot($filename, $line, $options);
@@ -168,6 +169,7 @@ function:
  *      @type string $condition
  *      @type array $expressions
  *      @type string $currentFile
+ *      @type callable $callable
  * }
  */
 function stackdriver_debugger_add_logpoint($filename, $line, $logLevel, $format, $options);

--- a/php_stackdriver_debugger.h
+++ b/php_stackdriver_debugger.h
@@ -44,6 +44,7 @@ PHP_RSHUTDOWN_FUNCTION(stackdriver_debugger);
 
 ZEND_BEGIN_MODULE_GLOBALS(stackdriver_debugger)
     HashTable *whitelisted_functions;
+    HashTable *user_whitelisted_functions;
 
     /* map of filename -> stackdriver_debugger_snapshot[] */
     HashTable *snapshots_by_file;

--- a/stackdriver_debugger.c
+++ b/stackdriver_debugger.c
@@ -437,7 +437,6 @@ PHP_MSHUTDOWN_FUNCTION(stackdriver_debugger)
     stackdriver_debugger_ast_mshutdown(SHUTDOWN_FUNC_ARGS_PASSTHRU);
     UNREGISTER_INI_ENTRIES();
 
-
     return SUCCESS;
 }
 /* }}} */

--- a/stackdriver_debugger.c
+++ b/stackdriver_debugger.c
@@ -16,11 +16,13 @@
 
 #include "php.h"
 #include "standard/php_string.h"
+#include "standard/info.h"
 #include "php_stackdriver_debugger.h"
 #include "stackdriver_debugger.h"
 #include "stackdriver_debugger_ast.h"
 #include "stackdriver_debugger_logpoint.h"
 #include "stackdriver_debugger_snapshot.h"
+#include "zend_exceptions.h"
 
 ZEND_DECLARE_MODULE_GLOBALS(stackdriver_debugger)
 

--- a/stackdriver_debugger.c
+++ b/stackdriver_debugger.c
@@ -290,7 +290,7 @@ PHP_FUNCTION(stackdriver_debugger_add_snapshot)
     zend_string *filename, *full_filename, *snapshot_id = NULL, *condition = NULL, *current_file = NULL;
     zend_long lineno;
     HashTable *options = NULL, *expressions = NULL;
-    zval *zv = NULL;
+    zval *zv = NULL, *callback = NULL;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Sl|h", &filename, &lineno, &options) == FAILURE) {
         RETURN_FALSE;
@@ -316,6 +316,11 @@ PHP_FUNCTION(stackdriver_debugger_add_snapshot)
         if (zv != NULL && !Z_ISNULL_P(zv)) {
             current_file = Z_STR_P(zv);
         }
+
+        zv = zend_hash_str_find(options, "callback", strlen("callback"));
+        if (zv != NULL && !Z_ISNULL_P(zv)) {
+            callback = zv;
+        }
     }
 
     if (current_file == NULL) {
@@ -324,7 +329,7 @@ PHP_FUNCTION(stackdriver_debugger_add_snapshot)
 
     full_filename = stackdriver_debugger_full_filename(filename, current_file);
 
-    if (register_snapshot(snapshot_id, full_filename, lineno, condition, expressions) != SUCCESS) {
+    if (register_snapshot(snapshot_id, full_filename, lineno, condition, expressions, callback) != SUCCESS) {
         zend_string_release(full_filename);
         RETURN_FALSE;
     }
@@ -355,7 +360,7 @@ PHP_FUNCTION(stackdriver_debugger_add_logpoint)
     zend_string *filename, *full_filename, *format = NULL, *snapshot_id = NULL, *condition = NULL, *current_file = NULL, *log_level = NULL;
     zend_long lineno;
     HashTable *options = NULL, *expressions = NULL;
-    zval *zv, *callback;
+    zval *zv = NULL, *callback = NULL;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SlSS|h", &filename, &lineno, &log_level, &format, &options) == FAILURE) {
         RETURN_FALSE;

--- a/stackdriver_debugger.c
+++ b/stackdriver_debugger.c
@@ -355,7 +355,7 @@ PHP_FUNCTION(stackdriver_debugger_add_logpoint)
     zend_string *filename, *full_filename, *format = NULL, *snapshot_id = NULL, *condition = NULL, *current_file = NULL, *log_level = NULL;
     zend_long lineno;
     HashTable *options = NULL, *expressions = NULL;
-    zval *zv;
+    zval *zv, *callback;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SlSS|h", &filename, &lineno, &log_level, &format, &options) == FAILURE) {
         RETURN_FALSE;
@@ -381,6 +381,11 @@ PHP_FUNCTION(stackdriver_debugger_add_logpoint)
         if (zv != NULL && !Z_ISNULL_P(zv)) {
             current_file = Z_STR_P(zv);
         }
+
+        zv = zend_hash_str_find(options, "callback", strlen("callback"));
+        if (zv != NULL && !Z_ISNULL_P(zv)) {
+            callback = zv;
+        }
     }
 
     if (current_file == NULL) {
@@ -389,7 +394,7 @@ PHP_FUNCTION(stackdriver_debugger_add_logpoint)
 
     full_filename = stackdriver_debugger_full_filename(filename, current_file);
 
-    if (register_logpoint(snapshot_id, full_filename, lineno, log_level, condition, format, expressions) != SUCCESS) {
+    if (register_logpoint(snapshot_id, full_filename, lineno, log_level, condition, format, expressions, callback) != SUCCESS) {
         zend_string_release(full_filename);
         RETURN_FALSE;
     }

--- a/stackdriver_debugger_ast.c
+++ b/stackdriver_debugger_ast.c
@@ -20,11 +20,10 @@
 #include "stackdriver_debugger_logpoint.h"
 #include "zend_language_scanner.h"
 #include "zend_exceptions.h"
+#include "main/php_ini.h"
 
 /* True global for storing the original zend_ast_process */
 static void (*original_zend_ast_process)(zend_ast*);
-
-static HashTable *user_whitelisted_functions = NULL;
 
 /**
  * This method generates a new abstract syntax tree that injects a function
@@ -185,7 +184,6 @@ static int inject_ast(zend_ast *ast, zend_ast_list *to_insert)
     } else {
         /* number of nodes */
         num_children = ast->kind >> ZEND_AST_NUM_CHILDREN_SHIFT;
-        // php_printf("num children node: %d\n", num_children);
         for (i = num_children - 1; i >= 0; i--) {
             current = ast->child[i];
             if (inject_ast(current, to_insert) == SUCCESS) {
@@ -292,8 +290,8 @@ static int valid_debugger_call(zend_ast *ast)
             return SUCCESS;
         }
 
-        if (user_whitelisted_functions &&
-            zend_hash_find(user_whitelisted_functions, function_name) != NULL) {
+        if (STACKDRIVER_DEBUGGER_G(user_whitelisted_functions) &&
+            zend_hash_find(STACKDRIVER_DEBUGGER_G(user_whitelisted_functions), function_name) != NULL) {
             return SUCCESS;
         }
     }
@@ -423,6 +421,22 @@ int valid_debugger_statement(zend_string *statement)
     CG(ast_arena) = NULL;
 
     return SUCCESS;
+}
+
+static void register_user_whitelisted_functions_str(const char *str, int len)
+{
+    char *key = NULL, *last = NULL;
+    char *tmp = estrndup(str, len);
+
+    for (key = php_strtok_r(tmp, ",", &last); key; key = php_strtok_r(NULL, ",", &last)) {
+        zend_hash_str_add_empty_element(STACKDRIVER_DEBUGGER_G(user_whitelisted_functions), key, strlen(key));
+    }
+    efree(tmp);
+}
+
+static void register_user_whitelisted_functions(zend_string *ini_setting)
+{
+    register_user_whitelisted_functions_str(ZSTR_VAL(ini_setting), ZSTR_LEN(ini_setting));
 }
 
 #define WHITELIST_FUNCTION(function_name) zend_hash_str_add_empty_element(ht, function_name, strlen(function_name))
@@ -679,16 +693,25 @@ int stackdriver_debugger_ast_rinit(TSRMLS_D)
     zend_hash_init(STACKDRIVER_DEBUGGER_G(whitelisted_functions), 1024, NULL, ZVAL_PTR_DTOR, 1);
     register_whitelisted_functions(STACKDRIVER_DEBUGGER_G(whitelisted_functions));
 
-    // ALLOC_HASHTABLE(user_whitelisted_functions);
-    // zend_hash_init(user_whitelisted_functions, 8, NULL, ZVAL_PTR_DTOR, 1);
+    ALLOC_HASHTABLE(STACKDRIVER_DEBUGGER_G(user_whitelisted_functions));
+    zend_hash_init(STACKDRIVER_DEBUGGER_G(user_whitelisted_functions), 8, NULL, ZVAL_PTR_DTOR, 1);
+
+    char *ini = php_ini_string(
+        PHP_STACKDRIVER_DEBUGGER_INI_WHITELISTED_FUNCTIONS,
+        sizeof(PHP_STACKDRIVER_DEBUGGER_INI_WHITELISTED_FUNCTIONS) - 1,
+        0
+    );
+    if (ini) {
+        register_user_whitelisted_functions_str(ini, strlen(ini));
+    }
 
     return SUCCESS;
 }
 
 int stackdriver_debugger_ast_rshutdown(TSRMLS_D)
 {
-    /* Clean up whitelisted function HashTable memory */
     zend_hash_destroy(STACKDRIVER_DEBUGGER_G(whitelisted_functions));
+    zend_hash_destroy(STACKDRIVER_DEBUGGER_G(user_whitelisted_functions));
 
     return SUCCESS;
 }
@@ -706,11 +729,6 @@ int stackdriver_debugger_ast_minit(INIT_FUNC_ARGS)
     original_zend_ast_process = zend_ast_process;
     zend_ast_process = stackdriver_debugger_ast_process;
 
-    if (user_whitelisted_functions == NULL) {
-        ALLOC_HASHTABLE(user_whitelisted_functions);
-        zend_hash_init(user_whitelisted_functions, 8, NULL, ZVAL_PTR_DTOR, 1);
-    }
-
     return SUCCESS;
 }
 
@@ -721,29 +739,13 @@ int stackdriver_debugger_ast_mshutdown(SHUTDOWN_FUNC_ARGS)
 {
     zend_ast_process = original_zend_ast_process;
 
-    if (user_whitelisted_functions != NULL) {
-        zend_hash_destroy(user_whitelisted_functions);
-    }
-
     return SUCCESS;
 }
 
 PHP_INI_MH(OnUpdate_stackdriver_debugger_whitelisted_functions)
 {
-    if (new_value) {
-        char *key = NULL, *last = NULL;
-        HashTable *ht = user_whitelisted_functions;
-        char *tmp = estrndup(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
-
-        if (user_whitelisted_functions == NULL) {
-            ALLOC_HASHTABLE(user_whitelisted_functions);
-            zend_hash_init(user_whitelisted_functions, 8, NULL, ZVAL_PTR_DTOR, 1);
-        }
-
-        for (key = php_strtok_r(tmp, ",", &last); key; key = php_strtok_r(NULL, ",", &last)) {
-            zend_hash_str_add_empty_element(user_whitelisted_functions, key, strlen(key));
-        }
-        efree(tmp);
+    if (new_value && STACKDRIVER_DEBUGGER_G(user_whitelisted_functions)) {
+        register_user_whitelisted_functions(new_value);
     }
 
     return SUCCESS;

--- a/stackdriver_debugger_ast.c
+++ b/stackdriver_debugger_ast.c
@@ -280,9 +280,11 @@ static int compile_ast(zend_string *source, zend_ast **ast_p, zend_lex_state *or
     return SUCCESS;
 }
 
+/**
+ * Determine if the allowed function call is whitelisted.
+ */
 static int valid_debugger_call(zend_ast *ast)
 {
-    // return FAILURE;
     zend_string *function_name = zend_ast_get_str(ast);
     zval *zv;
     if (function_name) {
@@ -686,6 +688,9 @@ static int register_whitelisted_functions(HashTable *ht)
     return SUCCESS;
 }
 
+/**
+ * Request initialization lifecycle hook. Sets up the function whitelist.
+ */
 int stackdriver_debugger_ast_rinit(TSRMLS_D)
 {
     /* Setup storage for whitelisted functions */
@@ -708,6 +713,9 @@ int stackdriver_debugger_ast_rinit(TSRMLS_D)
     return SUCCESS;
 }
 
+/**
+ * Request shutdown lifecycle hook. Cleans up the function whitelist.
+ */
 int stackdriver_debugger_ast_rshutdown(TSRMLS_D)
 {
     zend_hash_destroy(STACKDRIVER_DEBUGGER_G(whitelisted_functions));
@@ -742,11 +750,11 @@ int stackdriver_debugger_ast_mshutdown(SHUTDOWN_FUNC_ARGS)
     return SUCCESS;
 }
 
+/**
+ * Callback for when the user changes the function whitelist php.ini setting.
+ */
 PHP_INI_MH(OnUpdate_stackdriver_debugger_whitelisted_functions)
 {
-    if (new_value && STACKDRIVER_DEBUGGER_G(user_whitelisted_functions)) {
-        register_user_whitelisted_functions(new_value);
-    }
-
+    /* For now do nothing. */
     return SUCCESS;
 }

--- a/stackdriver_debugger_ast.c
+++ b/stackdriver_debugger_ast.c
@@ -19,6 +19,7 @@
 #include "stackdriver_debugger_snapshot.h"
 #include "stackdriver_debugger_logpoint.h"
 #include "zend_language_scanner.h"
+#include "zend_exceptions.h"
 
 /* True global for storing the original zend_ast_process */
 static void (*original_zend_ast_process)(zend_ast*);
@@ -689,6 +690,7 @@ int stackdriver_debugger_ast_rshutdown(TSRMLS_D)
     /* Clean up whitelisted function HashTable memory */
     zend_hash_destroy(STACKDRIVER_DEBUGGER_G(whitelisted_functions));
 
+    return SUCCESS;
 }
 
 /**

--- a/stackdriver_debugger_ast.c
+++ b/stackdriver_debugger_ast.c
@@ -721,7 +721,9 @@ int stackdriver_debugger_ast_mshutdown(SHUTDOWN_FUNC_ARGS)
 {
     zend_ast_process = original_zend_ast_process;
 
-    zend_hash_destroy(user_whitelisted_functions);
+    if (user_whitelisted_functions != NULL) {
+        zend_hash_destroy(user_whitelisted_functions);
+    }
 
     return SUCCESS;
 }

--- a/stackdriver_debugger_ast.h
+++ b/stackdriver_debugger_ast.h
@@ -23,6 +23,8 @@ int valid_debugger_statement(zend_string *statement);
 void stackdriver_debugger_ast_process(zend_ast *ast);
 int stackdriver_debugger_ast_minit(INIT_FUNC_ARGS);
 int stackdriver_debugger_ast_mshutdown(SHUTDOWN_FUNC_ARGS);
+int stackdriver_debugger_ast_rinit(TSRMLS_D);
+int stackdriver_debugger_ast_rshutdown(TSRMLS_D);
 
 PHP_INI_MH(OnUpdate_stackdriver_debugger_whitelisted_functions);
 

--- a/stackdriver_debugger_logpoint.c
+++ b/stackdriver_debugger_logpoint.c
@@ -170,12 +170,12 @@ void evaluate_logpoint(zend_execute_data *execute_data, stackdriver_debugger_log
     }
     ZVAL_STR(&message->message, m);
 
-    // printf("callback type: %d\n", Z_TYPE(logpoint->callback));
     if (!Z_ISUNDEF(logpoint->callback) && !Z_ISNULL(logpoint->callback)) {
         emit_message(&logpoint->callback, message);
+        destroy_message(message);
+    } else {
+        zend_hash_next_index_insert_ptr(STACKDRIVER_DEBUGGER_G(collected_messages), message);
     }
-
-    zend_hash_next_index_insert_ptr(STACKDRIVER_DEBUGGER_G(collected_messages), message);
 }
 
 /**

--- a/stackdriver_debugger_logpoint.c
+++ b/stackdriver_debugger_logpoint.c
@@ -177,7 +177,13 @@ void evaluate_logpoint(zend_execute_data *execute_data, stackdriver_debugger_log
     ZVAL_STR(&message->message, m);
 
     if (logpoint->callback) {
-        handle_message_callback(logpoint->callback, message);
+        if (handle_message_callback(logpoint->callback, message) != SUCCESS) {
+            php_error_docref(NULL, E_WARNING, "Error running logpoint callback.");
+        }
+        if (EG(exception) != NULL) {
+            zend_clear_exception();
+            php_error_docref(NULL, E_WARNING, "Error running logpoint callback.");
+        }
         destroy_message(message);
     } else {
         zend_hash_next_index_insert_ptr(STACKDRIVER_DEBUGGER_G(collected_messages), message);

--- a/stackdriver_debugger_logpoint.c
+++ b/stackdriver_debugger_logpoint.c
@@ -18,10 +18,11 @@
 #include "php_stackdriver_debugger.h"
 #include "stackdriver_debugger_ast.h"
 #include "stackdriver_debugger_logpoint.h"
-#include "standard/php_mt_rand.h"
 
 #if PHP_VERSION_ID < 70100
 #include "standard/php_rand.h"
+#else
+#include "standard/php_mt_rand.h"
 #endif
 
 #ifdef _WIN32

--- a/stackdriver_debugger_logpoint.c
+++ b/stackdriver_debugger_logpoint.c
@@ -119,7 +119,7 @@ static void destroy_message(stackdriver_debugger_message_t *message)
     efree(message);
 }
 
-static int emit_message(zval *callback, stackdriver_debugger_message_t *message)
+static int handle_message_callback(zval *callback, stackdriver_debugger_message_t *message)
 {
     zval callback_result;
     zval args[3];
@@ -171,7 +171,7 @@ void evaluate_logpoint(zend_execute_data *execute_data, stackdriver_debugger_log
     ZVAL_STR(&message->message, m);
 
     if (!Z_ISUNDEF(logpoint->callback) && !Z_ISNULL(logpoint->callback)) {
-        emit_message(&logpoint->callback, message);
+        handle_message_callback(&logpoint->callback, message);
         destroy_message(message);
     } else {
         zend_hash_next_index_insert_ptr(STACKDRIVER_DEBUGGER_G(collected_messages), message);

--- a/stackdriver_debugger_logpoint.c
+++ b/stackdriver_debugger_logpoint.c
@@ -170,7 +170,8 @@ void evaluate_logpoint(zend_execute_data *execute_data, stackdriver_debugger_log
     }
     ZVAL_STR(&message->message, m);
 
-    if (Z_TYPE(logpoint->callback) != IS_NULL) {
+    // printf("callback type: %d\n", Z_TYPE(logpoint->callback));
+    if (!Z_ISUNDEF(logpoint->callback) && !Z_ISNULL(logpoint->callback)) {
         emit_message(&logpoint->callback, message);
     }
 

--- a/stackdriver_debugger_logpoint.h
+++ b/stackdriver_debugger_logpoint.h
@@ -27,6 +27,7 @@ typedef struct stackdriver_debugger_logpoint_t {
     zend_string *log_level;
 
     zend_string *format;
+    zval callback;
 
     HashTable *expressions;
 } stackdriver_debugger_logpoint_t;

--- a/stackdriver_debugger_logpoint.h
+++ b/stackdriver_debugger_logpoint.h
@@ -46,5 +46,9 @@ typedef struct stackdriver_debugger_message_t {
 void evaluate_logpoint(zend_execute_data *execute_data, stackdriver_debugger_logpoint_t *logpoint);
 int stackdriver_debugger_logpoint_rinit(TSRMLS_D);
 int stackdriver_debugger_logpoint_rshutdown(TSRMLS_D);
+void list_logpoints(zval *return_value);
+int register_logpoint(zend_string *logpoint_id, zend_string *filename,
+    zend_long lineno, zend_string *log_level, zend_string *condition,
+    zend_string *format, HashTable *expressions, zval *callback);
 
 #endif /* PHP_STACKDRIVER_DEBUGGER_LOGPOINT_H */

--- a/stackdriver_debugger_logpoint.h
+++ b/stackdriver_debugger_logpoint.h
@@ -27,7 +27,7 @@ typedef struct stackdriver_debugger_logpoint_t {
     zend_string *log_level;
 
     zend_string *format;
-    zval callback;
+    zval *callback;
 
     HashTable *expressions;
 } stackdriver_debugger_logpoint_t;

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -459,7 +459,13 @@ void evaluate_snapshot(zend_execute_data *execute_data, stackdriver_debugger_sna
 
     /* record as collected */
     if (snapshot->callback) {
-        handle_snapshot_callback(snapshot->callback, snapshot);
+        if (handle_snapshot_callback(snapshot->callback, snapshot) != SUCCESS) {
+            php_error_docref(NULL, E_WARNING, "Error running snapshot callback.");
+        }
+        if (EG(exception) != NULL) {
+            zend_clear_exception();
+            php_error_docref(NULL, E_WARNING, "Error running snapshot callback.");
+        }
     } else {
         zend_hash_update_ptr(STACKDRIVER_DEBUGGER_G(collected_snapshots_by_id), snapshot->id, snapshot);
     }

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -18,7 +18,12 @@
 #include "php_stackdriver_debugger.h"
 #include "stackdriver_debugger_ast.h"
 #include "stackdriver_debugger_snapshot.h"
+
+#if PHP_VERSION_ID < 70100
+#include "standard/php_rand.h"
+#else
 #include "standard/php_mt_rand.h"
+#endif
 
 /* Initialize an empty, allocated variable */
 static void init_variable(stackdriver_debugger_variable_t *variable)
@@ -303,7 +308,7 @@ static int execute_data_to_stackframe(zend_execute_data *execute_data, stackdriv
  */
 int register_snapshot(zend_string *snapshot_id, zend_string *filename,
     zend_long lineno, zend_string *condition, HashTable *expressions,
-    HashTable *callback)
+    zval *callback)
 {
     zval *snapshots, *snapshot_ptr;
     stackdriver_debugger_snapshot_t *snapshot;

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -16,11 +16,9 @@
 
 #include "php.h"
 #include "php_stackdriver_debugger.h"
+#include "stackdriver_debugger_ast.h"
 #include "stackdriver_debugger_snapshot.h"
-
-#if PHP_VERSION_ID < 70100
-#include "standard/php_rand.h"
-#endif
+#include "standard/php_mt_rand.h"
 
 /* Initialize an empty, allocated variable */
 static void init_variable(stackdriver_debugger_variable_t *variable)
@@ -325,7 +323,7 @@ int register_snapshot(zend_string *snapshot_id, zend_string *filename, zend_long
         zend_hash_init(snapshot->expressions, expressions->nNumUsed, NULL, ZVAL_PTR_DTOR, 0);
 
         ZEND_HASH_FOREACH_VAL(expressions, expression) {
-            if (valid_debugger_statement(expression) != SUCCESS) {
+            if (valid_debugger_statement(Z_STR_P(expression)) != SUCCESS) {
                 return FAILURE;
             }
             zend_hash_next_index_insert(snapshot->expressions, expression);

--- a/stackdriver_debugger_snapshot.h
+++ b/stackdriver_debugger_snapshot.h
@@ -41,7 +41,7 @@ typedef struct stackdriver_debugger_snapshot_t {
     zend_string *condition;
     zend_bool fulfilled;
 
-    zval callback;
+    zval *callback;
 
     /* index => zval* (strings) */
     HashTable *expressions;

--- a/stackdriver_debugger_snapshot.h
+++ b/stackdriver_debugger_snapshot.h
@@ -56,7 +56,7 @@ typedef struct stackdriver_debugger_snapshot_t {
 
 void evaluate_snapshot(zend_execute_data *execute_data, stackdriver_debugger_snapshot_t *snapshot);
 void list_snapshots(zval *return_value);
-int register_snapshot(zend_string *snapshot_id, zend_string *filename, zend_long lineno, zend_string *condition, HashTable *expressions, HashTable *callback);
+int register_snapshot(zend_string *snapshot_id, zend_string *filename, zend_long lineno, zend_string *condition, HashTable *expressions, zval *callback);
 
 /* request lifecycle callbacks */
 int stackdriver_debugger_snapshot_rinit(TSRMLS_D);

--- a/stackdriver_debugger_snapshot.h
+++ b/stackdriver_debugger_snapshot.h
@@ -41,6 +41,8 @@ typedef struct stackdriver_debugger_snapshot_t {
     zend_string *condition;
     zend_bool fulfilled;
 
+    zval callback;
+
     /* index => zval* (strings) */
     HashTable *expressions;
 
@@ -54,7 +56,7 @@ typedef struct stackdriver_debugger_snapshot_t {
 
 void evaluate_snapshot(zend_execute_data *execute_data, stackdriver_debugger_snapshot_t *snapshot);
 void list_snapshots(zval *return_value);
-int register_snapshot(zend_string *snapshot_id, zend_string *filename, zend_long lineno, zend_string *condition, HashTable *expressions);
+int register_snapshot(zend_string *snapshot_id, zend_string *filename, zend_long lineno, zend_string *condition, HashTable *expressions, HashTable *callback);
 
 /* request lifecycle callbacks */
 int stackdriver_debugger_snapshot_rinit(TSRMLS_D);

--- a/tests/function_whitelist_multiple.phpt
+++ b/tests/function_whitelist_multiple.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Stackdriver Debugger: Allowing multiple whitelisted functions
 --INI--
-stackdriver_debugger.function_whitelist=foo,bar
+stackdriver_debugger.function_whitelist="foo,bar"
 --FILE--
 <?php
 

--- a/tests/logpoints/callback.phpt
+++ b/tests/logpoints/callback.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Stackdriver Debugger: Logpoint callback
+--FILE--
+<?php
+
+function logpoint_callback($level, $message) {
+    echo "logpoint: $level - $message" . PHP_EOL;
+}
+
+// set a snapshot for line 7 in loop.php ($sum += $i)
+var_dump(stackdriver_debugger_add_logpoint('loop.php', 7, 'INFO', 'Logpoint hit!', [
+  'callback' => 'logpoint_callback'
+]));
+
+require_once(__DIR__ . '/loop.php');
+
+$sum = loop(10);
+
+echo "Sum is {$sum}\n";
+?>
+--EXPECTF--
+bool(true)
+logpoint: INFO - Logpoint hit!
+logpoint: INFO - Logpoint hit!
+logpoint: INFO - Logpoint hit!
+logpoint: INFO - Logpoint hit!
+logpoint: INFO - Logpoint hit!
+logpoint: INFO - Logpoint hit!
+logpoint: INFO - Logpoint hit!
+logpoint: INFO - Logpoint hit!
+logpoint: INFO - Logpoint hit!
+logpoint: INFO - Logpoint hit!
+Sum is 45

--- a/tests/logpoints/callback_context.phpt
+++ b/tests/logpoints/callback_context.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Stackdriver Debugger: Logpoint callback context
+--FILE--
+<?php
+
+function logpoint_callback($level, $message, $context) {
+    $file = basename($context['filename']);
+    $line = $context['line'];
+    echo "logpoint: $level - $message $file:$line" . PHP_EOL;
+}
+
+// set a snapshot for line 7 in loop.php ($sum += $i)
+var_dump(stackdriver_debugger_add_logpoint('loop.php', 7, 'INFO', 'Logpoint hit!', [
+  'callback' => 'logpoint_callback'
+]));
+
+require_once(__DIR__ . '/loop.php');
+
+$sum = loop(10);
+
+echo "Sum is {$sum}\n";
+?>
+--EXPECTF--
+bool(true)
+logpoint: INFO - Logpoint hit! loop.php:7
+logpoint: INFO - Logpoint hit! loop.php:7
+logpoint: INFO - Logpoint hit! loop.php:7
+logpoint: INFO - Logpoint hit! loop.php:7
+logpoint: INFO - Logpoint hit! loop.php:7
+logpoint: INFO - Logpoint hit! loop.php:7
+logpoint: INFO - Logpoint hit! loop.php:7
+logpoint: INFO - Logpoint hit! loop.php:7
+logpoint: INFO - Logpoint hit! loop.php:7
+logpoint: INFO - Logpoint hit! loop.php:7
+Sum is 45

--- a/tests/logpoints/callback_exception.phpt
+++ b/tests/logpoints/callback_exception.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Stackdriver Debugger: Logpoint callback exception should be caught and cleared
+--FILE--
+<?php
+
+function logpoint_callback($level, $message) {
+    throw new RuntimeException("error in logpoint callback");
+}
+
+// set a snapshot for line 7 in loop.php ($sum += $i)
+var_dump(stackdriver_debugger_add_logpoint('loop.php', 7, 'INFO', 'Logpoint hit!', [
+  'callback' => 'logpoint_callback'
+]));
+
+require_once(__DIR__ . '/loop.php');
+
+$sum = loop(10);
+
+echo "Sum is {$sum}\n";
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stackdriver_debugger_logpoint(): Error running logpoint callback. in %s on line %d
+
+Warning: stackdriver_debugger_logpoint(): Error running logpoint callback. in %s on line %d
+
+Warning: stackdriver_debugger_logpoint(): Error running logpoint callback. in %s on line %d
+
+Warning: stackdriver_debugger_logpoint(): Error running logpoint callback. in %s on line %d
+
+Warning: stackdriver_debugger_logpoint(): Error running logpoint callback. in %s on line %d
+
+Warning: stackdriver_debugger_logpoint(): Error running logpoint callback. in %s on line %d
+
+Warning: stackdriver_debugger_logpoint(): Error running logpoint callback. in %s on line %d
+
+Warning: stackdriver_debugger_logpoint(): Error running logpoint callback. in %s on line %d
+
+Warning: stackdriver_debugger_logpoint(): Error running logpoint callback. in %s on line %d
+
+Warning: stackdriver_debugger_logpoint(): Error running logpoint callback. in %s on line %d
+Sum is 45

--- a/tests/snapshots/callback.phpt
+++ b/tests/snapshots/callback.phpt
@@ -34,7 +34,7 @@ echo "Number of breakpoints: " . count($list) . PHP_EOL;
 bool(true)
 Number of stackframes: 2
 loop.php:7
-basic_variable_dump.php:8
+callback.php:22
 array(4) {
   [0]=>
   array(2) {

--- a/tests/snapshots/callback.phpt
+++ b/tests/snapshots/callback.phpt
@@ -1,0 +1,69 @@
+--TEST--
+Stackdriver Debugger: Snapshot callback
+--FILE--
+<?php
+
+function handle_snapshot($breakpoint)
+{
+    echo "Number of stackframes: " . count($breakpoint['stackframes']) . PHP_EOL;
+
+    foreach ($breakpoint['stackframes'] as $sf) {
+        echo basename($sf['filename']) . ":" . $sf['line'] . PHP_EOL;
+    }
+
+    $loopStackframe = $breakpoint['stackframes'][0];
+    var_dump($loopStackframe['locals']);
+}
+
+// set a snapshot for line 7 in loop.php ($sum += $i)
+var_dump(stackdriver_debugger_add_snapshot('loop.php', 7, [
+  'callback' => 'handle_snapshot'
+]));
+
+require_once(__DIR__ . '/loop.php');
+
+$sum = loop(10);
+
+echo "Sum is {$sum}\n";
+
+$list = stackdriver_debugger_list_snapshots();
+
+echo "Number of breakpoints: " . count($list) . PHP_EOL;
+?>
+--EXPECTF--
+bool(true)
+Number of stackframes: 2
+loop.php:7
+basic_variable_dump.php:8
+array(4) {
+  [0]=>
+  array(2) {
+    ["name"]=>
+    string(5) "times"
+    ["value"]=>
+    int(10)
+  }
+  [1]=>
+  array(2) {
+    ["name"]=>
+    string(3) "sum"
+    ["value"]=>
+    int(0)
+  }
+  [2]=>
+  array(2) {
+    ["name"]=>
+    string(1) "i"
+    ["value"]=>
+    int(0)
+  }
+  [3]=>
+  array(2) {
+    ["name"]=>
+    string(1) "j"
+    ["value"]=>
+    NULL
+  }
+}
+Sum is 45
+Number of breakpoints: 0

--- a/tests/snapshots/callback_exception.phpt
+++ b/tests/snapshots/callback_exception.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Stackdriver Debugger: Snapshot callback exception should be caught and cleared
+--FILE--
+<?php
+
+function handle_snapshot($breakpoint)
+{
+    throw new RuntimeException('exception in snapshot handler');
+}
+
+// set a snapshot for line 7 in loop.php ($sum += $i)
+var_dump(stackdriver_debugger_add_snapshot('loop.php', 7, [
+  'callback' => 'handle_snapshot'
+]));
+
+require_once(__DIR__ . '/loop.php');
+
+$sum = loop(10);
+
+echo "Sum is {$sum}\n";
+
+$list = stackdriver_debugger_list_snapshots();
+
+echo "Number of breakpoints: " . count($list) . PHP_EOL;
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stackdriver_debugger_snapshot(): Error running snapshot callback. in %s on line %d
+Sum is 45
+Number of breakpoints: 0


### PR DESCRIPTION
When registering a snapshot or breakpoint, you can provide an optional `callback` option which is a PHP callable type. Rather than storing the snapshot or log message for retrieval at the end of the request, the callback is invoked.

The snapshot callback receives the snapshot array of data. The logpoint callback receives the log level, the log message, and an array of context which is compatible with a PSR-3 logger's implementation of `log($level, $message, array $context = [])`.

The callback allows us to send the data back to the server ASAP, rather than waiting until the end of the request. We will also not have to manage cleaning up memory at the end of the request.

We may decide to make this required rather than allow collection for the end of the request.

Fixes #3 