### PR TITLE
Fix memory leaks and add tests for memory leaks

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,6 +25,10 @@ steps:
     waitFor: ['-']
     id: php72-zts
   - name: gcr.io/cloud-builders/docker
+    args: ['build', '--build-arg', 'BASE_IMAGE=gcr.io/google-appengine/php72', '.']
+    waitFor: ['-']
+    id: php72-gae
+  - name: gcr.io/cloud-builders/docker
     args: ['build', '--build-arg', 'BASE_IMAGE=gcr.io/google-appengine/php71', '.']
     waitFor: ['-']
     id: php71-gae
@@ -33,6 +37,6 @@ steps:
     waitFor: ['-']
     id: php70-gae
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '--build-arg', 'BASE_IMAGE=gcr.io/php-mvm-a/php72:rc3', '.']
+    args: ['build', '--build-arg', 'BASE_IMAGE=gcr.io/php-stackdriver/php71-debug', '.']
     waitFor: ['-']
-    id: php72-gae
+    id: php71-debug

--- a/php_stackdriver_debugger.h
+++ b/php_stackdriver_debugger.h
@@ -64,6 +64,9 @@ ZEND_BEGIN_MODULE_GLOBALS(stackdriver_debugger)
     /* array of stackdriver_debugger_message_t */
     HashTable *collected_messages;
 
+    /* array of pointers to ast node types */
+    HashTable *ast_to_clean;
+
 ZEND_END_MODULE_GLOBALS(stackdriver_debugger)
 
 extern ZEND_DECLARE_MODULE_GLOBALS(stackdriver_debugger)

--- a/stackdriver_debugger.c
+++ b/stackdriver_debugger.c
@@ -457,6 +457,7 @@ PHP_RSHUTDOWN_FUNCTION(stackdriver_debugger)
     stackdriver_debugger_ast_rshutdown(TSRMLS_C);
     stackdriver_debugger_snapshot_rshutdown(TSRMLS_C);
     stackdriver_debugger_logpoint_rshutdown(TSRMLS_C);
+
     return SUCCESS;
 }
 /* }}} */

--- a/stackdriver_debugger_ast.c
+++ b/stackdriver_debugger_ast.c
@@ -125,10 +125,6 @@ static int inject_ast(zend_ast *ast, zend_ast_list *to_insert)
         }
     }
 
-    if (ast->lineno > to_insert->lineno) {
-        return FAILURE;
-    }
-
     if (ast->kind == ZEND_AST_STMT_LIST) {
         list = zend_ast_get_list(ast);
 

--- a/stackdriver_debugger_ast.c
+++ b/stackdriver_debugger_ast.c
@@ -125,6 +125,10 @@ static int inject_ast(zend_ast *ast, zend_ast_list *to_insert)
         }
     }
 
+    if (ast->lineno > to_insert->lineno) {
+        return FAILURE;
+    }
+
     if (ast->kind == ZEND_AST_STMT_LIST) {
         list = zend_ast_get_list(ast);
 
@@ -217,7 +221,7 @@ void stackdriver_debugger_ast_process(zend_ast *ast)
                 snapshot->id,
                 snapshot->lineno
             );
-            inject_ast(ast, to_insert);
+            int ret = inject_ast(ast, to_insert);
         } ZEND_HASH_FOREACH_END();
     }
 

--- a/stackdriver_debugger_ast.c
+++ b/stackdriver_debugger_ast.c
@@ -395,7 +395,6 @@ int valid_debugger_statement(zend_string *statement)
 {
     zend_lex_state original_lex_state;
     zend_ast *ast_p;
-    ast_p = emalloc(sizeof(zend_ast*));
 
     /*
      * Append ';' to the end for lexing/parsing. Evaluating the statement
@@ -719,7 +718,9 @@ int stackdriver_debugger_ast_rinit(TSRMLS_D)
 int stackdriver_debugger_ast_rshutdown(TSRMLS_D)
 {
     zend_hash_destroy(STACKDRIVER_DEBUGGER_G(whitelisted_functions));
+    FREE_HASHTABLE(STACKDRIVER_DEBUGGER_G(whitelisted_functions));
     zend_hash_destroy(STACKDRIVER_DEBUGGER_G(user_whitelisted_functions));
+    FREE_HASHTABLE(STACKDRIVER_DEBUGGER_G(user_whitelisted_functions));
 
     return SUCCESS;
 }

--- a/stackdriver_debugger_ast.c
+++ b/stackdriver_debugger_ast.c
@@ -221,7 +221,7 @@ void stackdriver_debugger_ast_process(zend_ast *ast)
                 snapshot->id,
                 snapshot->lineno
             );
-            int ret = inject_ast(ast, to_insert);
+            inject_ast(ast, to_insert);
         } ZEND_HASH_FOREACH_END();
     }
 

--- a/stackdriver_debugger_ast.c
+++ b/stackdriver_debugger_ast.c
@@ -51,30 +51,30 @@ static zend_ast_list *create_debugger_ast(const char *callback, zend_string *bre
     zend_ast_zval *var, *snapshot_id;
     zend_ast_list *new_list, *arg_list;
 
-    var = emalloc(sizeof(zend_ast_zval));
+    var = emalloc(sizeof(zend_ast_zval)); // FIXME
     var->kind = ZEND_AST_ZVAL;
     ZVAL_STRING(&var->val, callback);
     var->val.u2.lineno = lineno;
 
-    snapshot_id = emalloc(sizeof(zend_ast_zval));
+    snapshot_id = emalloc(sizeof(zend_ast_zval)); // FIXME
     snapshot_id->kind = ZEND_AST_ZVAL;
     ZVAL_STR_COPY(&snapshot_id->val, breakpoint_id);
     snapshot_id->val.u2.lineno = lineno;
 
-    arg_list = emalloc(sizeof(zend_ast_list) + sizeof(zend_ast*));
+    arg_list = emalloc(sizeof(zend_ast_list) + sizeof(zend_ast*)); // FIXME
     arg_list->kind = ZEND_AST_ARG_LIST;
     arg_list->lineno = lineno;
     arg_list->children = 1;
     arg_list->child[0] = (zend_ast*)snapshot_id;
 
-    new_call = emalloc(sizeof(zend_ast) + sizeof(zend_ast*));
+    new_call = emalloc(sizeof(zend_ast) + sizeof(zend_ast*)); // FIXME
     new_call->kind = ZEND_AST_CALL;
     new_call->lineno = lineno;
     new_call->child[0] = (zend_ast*)var;
     new_call->child[1] = (zend_ast*)arg_list;
 
     /* create a new statement list */
-    new_list = emalloc(sizeof(zend_ast_list) + sizeof(zend_ast*));
+    new_list = emalloc(sizeof(zend_ast_list) + sizeof(zend_ast*)); // FIXME
     new_list->kind = ZEND_AST_STMT_LIST;
     new_list->lineno = lineno;
     new_list->children = 2;
@@ -247,7 +247,7 @@ static int compile_ast(zend_string *source, zend_ast **ast_p, zend_lex_state *or
 {
     zval source_zval;
 
-    ZVAL_STR_COPY(&source_zval, source);
+    ZVAL_STR(&source_zval, source);
     zend_save_lexical_state(original_lex_state);
 
     if (zend_prepare_string_for_scanning(&source_zval, "") == FAILURE) {
@@ -411,12 +411,16 @@ int valid_debugger_statement(zend_string *statement)
 
     if (valid_debugger_ast(ast_p) != SUCCESS) {
         php_error_docref(NULL, E_WARNING, "Condition contains invalid operations");
+        zend_ast_destroy(CG(ast));
+        zend_arena_destroy(CG(ast_arena));
         zend_restore_lexical_state(&original_lex_state);
         CG(ast) = NULL;
         CG(ast_arena) = NULL;
         return FAILURE;
     }
 
+    zend_ast_destroy(CG(ast));
+    zend_arena_destroy(CG(ast_arena));
     zend_restore_lexical_state(&original_lex_state);
     CG(ast) = NULL;
     CG(ast_arena) = NULL;

--- a/stackdriver_debugger_logpoint.c
+++ b/stackdriver_debugger_logpoint.c
@@ -172,6 +172,7 @@ void evaluate_logpoint(zend_execute_data *execute_data, stackdriver_debugger_log
                 zend_string_release(regex);
                 m = replaced;
             }
+            ZVAL_DESTRUCTOR(&retval);
         } ZEND_HASH_FOREACH_END();
     }
     ZVAL_STR(&message->message, m);

--- a/stackdriver_debugger_logpoint.c
+++ b/stackdriver_debugger_logpoint.c
@@ -128,8 +128,8 @@ static int handle_message_callback(zval *callback, stackdriver_debugger_message_
 {
     zval callback_result;
     zval args[3];
-    ZVAL_STR(&args[0], message->log_level);
-    args[1] = message->message;
+    ZVAL_STR(&args[0], zend_string_copy(message->log_level));
+    ZVAL_COPY(&args[1], &message->message);
     array_init(&args[2]);
     add_assoc_str(&args[2], "filename", message->filename);
     add_assoc_long(&args[2], "line", message->lineno);

--- a/stackdriver_debugger_logpoint.c
+++ b/stackdriver_debugger_logpoint.c
@@ -327,7 +327,10 @@ int stackdriver_debugger_logpoint_rinit(TSRMLS_D)
 int stackdriver_debugger_logpoint_rshutdown(TSRMLS_D)
 {
     zend_hash_destroy(STACKDRIVER_DEBUGGER_G(collected_messages));
+    FREE_HASHTABLE(STACKDRIVER_DEBUGGER_G(collected_messages));
     zend_hash_destroy(STACKDRIVER_DEBUGGER_G(logpoints_by_file));
+    FREE_HASHTABLE(STACKDRIVER_DEBUGGER_G(logpoints_by_file));
     zend_hash_destroy(STACKDRIVER_DEBUGGER_G(logpoints_by_id));
+    FREE_HASHTABLE(STACKDRIVER_DEBUGGER_G(logpoints_by_id));
     return SUCCESS;
 }

--- a/stackdriver_debugger_logpoint.h
+++ b/stackdriver_debugger_logpoint.h
@@ -27,7 +27,7 @@ typedef struct stackdriver_debugger_logpoint_t {
     zend_string *log_level;
 
     zend_string *format;
-    zval *callback;
+    zval callback;
 
     HashTable *expressions;
 } stackdriver_debugger_logpoint_t;

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -204,8 +204,8 @@ static void stackframes_to_zval(zval *return_value, stackdriver_debugger_snapsho
  */
 static void expressions_to_zval(zval *return_value, stackdriver_debugger_snapshot_t *snapshot)
 {
-    ZVAL_ARR(return_value, snapshot->evaluated_expressions);
-    Z_TRY_ADDREF_P(return_value);
+    array_init(return_value);
+    zend_hash_copy(Z_ARR_P(return_value), snapshot->evaluated_expressions, NULL);
 }
 
 static void snapshot_to_zval(zval *return_value, stackdriver_debugger_snapshot_t *snapshot)

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -43,14 +43,21 @@ static void destroy_variable(stackdriver_debugger_variable_t *variable)
     efree(variable);
 }
 
+static void stackframe_locals_dtor(zval *zv)
+{
+    stackdriver_debugger_variable_t *variable = (stackdriver_debugger_variable_t *)Z_PTR_P(zv);
+    destroy_variable(variable);
+    ZVAL_PTR_DTOR(zv);
+}
+
 /* Initialize an empty, allocated stackframe */
 static void init_stackframe(stackdriver_debugger_stackframe_t *stackframe)
 {
     stackframe->function = NULL;
     stackframe->filename = NULL;
     stackframe->lineno = -1;
-    stackframe->locals_count = 0;
-    stackframe->locals = NULL;
+    ALLOC_HASHTABLE(stackframe->locals);
+    zend_hash_init(stackframe->locals, 16, NULL, stackframe_locals_dtor, 0);
 }
 
 /* Cleanup an allocated stackframe including freeing memory */
@@ -66,11 +73,17 @@ static void destroy_stackframe(stackdriver_debugger_stackframe_t *stackframe)
         zend_string_release(stackframe->filename);
     }
 
-    for (i = 0; i < stackframe->locals_count; i ++) {
-        destroy_variable(stackframe->locals[i]);
-    }
-    efree(stackframe->locals);
+    zend_hash_destroy(stackframe->locals);
+    FREE_HASHTABLE(stackframe->locals);
+
     efree(stackframe);
+}
+
+static void stackframes_dtor(zval *zv)
+{
+    stackdriver_debugger_stackframe_t *sf = (stackdriver_debugger_stackframe_t *)Z_PTR_P(zv);
+    destroy_stackframe(sf);
+    ZVAL_PTR_DTOR(zv);
 }
 
 /* Initialize an empty, allocated snapshot */
@@ -81,10 +94,12 @@ static void init_snapshot(stackdriver_debugger_snapshot_t *snapshot)
     snapshot->lineno = -1;
     snapshot->condition = NULL;
     snapshot->fulfilled = 0;
-    snapshot->expressions = NULL;
-    snapshot->evaluated_expressions = NULL;
-    snapshot->stackframes_count = 0;
-    snapshot->stackframes = NULL;
+    ALLOC_HASHTABLE(snapshot->expressions);
+    zend_hash_init(snapshot->expressions, 16, NULL, ZVAL_PTR_DTOR, 0);
+    ALLOC_HASHTABLE(snapshot->evaluated_expressions);
+    zend_hash_init(snapshot->evaluated_expressions, 16, NULL, ZVAL_PTR_DTOR, 0);
+    ALLOC_HASHTABLE(snapshot->stackframes);
+    zend_hash_init(snapshot->stackframes, 16, NULL, stackframes_dtor, 0);
     snapshot->callback = NULL;
 }
 
@@ -100,23 +115,19 @@ static void destroy_snapshot(stackdriver_debugger_snapshot_t *snapshot)
         zend_string_release(snapshot->condition);
     }
 
-    if (snapshot->expressions) {
-        zend_hash_destroy(snapshot->expressions);
-    }
+    zend_hash_destroy(snapshot->expressions);
+    FREE_HASHTABLE(snapshot->expressions);
 
-    if (snapshot->evaluated_expressions) {
-        zend_hash_destroy(snapshot->evaluated_expressions);
-    }
+    zend_hash_destroy(snapshot->evaluated_expressions);
+    FREE_HASHTABLE(snapshot->evaluated_expressions);
 
     if (snapshot->callback) {
         ZVAL_PTR_DTOR(snapshot->callback);
         efree(snapshot->callback);
     }
 
-    for (i = 0; i < snapshot->stackframes_count; i++) {
-        destroy_stackframe(snapshot->stackframes[i]);
-    }
-    efree(snapshot->stackframes);
+    zend_hash_destroy(snapshot->stackframes);
+    FREE_HASHTABLE(snapshot->stackframes);
     efree(snapshot);
 }
 
@@ -163,16 +174,17 @@ static void stackframe_to_zval(zval *return_value, stackdriver_debugger_stackfra
     }
     add_assoc_str(return_value, "filename", stackframe->filename);
     add_assoc_long(return_value, "line", stackframe->lineno);
-    if (stackframe->locals_count) {
-        zval locals, local;
-        array_init(&locals);
-        for (i = 0; i < stackframe->locals_count; i++) {
-            variable_to_zval(&local, stackframe->locals[i]);
-            add_next_index_zval(&locals, &local);
-        }
 
-        add_assoc_zval(return_value, "locals", &locals);
-    }
+    zval locals;
+    array_init(&locals);
+    stackdriver_debugger_variable_t *local_variable;
+    ZEND_HASH_FOREACH_PTR(stackframe->locals, local_variable) {
+        zval local;
+        variable_to_zval(&local, local_variable);
+        add_next_index_zval(&locals, &local);
+    } ZEND_HASH_FOREACH_END();
+
+    add_assoc_zval(return_value, "locals", &locals);
 }
 
 /**
@@ -183,12 +195,13 @@ static void stackframes_to_zval(zval *return_value, stackdriver_debugger_snapsho
 {
     int i;
     array_init(return_value);
+    stackdriver_debugger_stackframe_t *stackframe;
 
-    for (i = 0; i < snapshot->stackframes_count; i++) {
-        zval stackframe;
-        stackframe_to_zval(&stackframe, snapshot->stackframes[i]);
-        add_next_index_zval(return_value, &stackframe);
-    }
+    ZEND_HASH_FOREACH_PTR(snapshot->stackframes, stackframe) {
+        zval zstackframe;
+        stackframe_to_zval(&zstackframe, stackframe);
+        add_next_index_zval(return_value, &zstackframe);
+    } ZEND_HASH_FOREACH_END();
 }
 
 /**
@@ -196,11 +209,6 @@ static void stackframes_to_zval(zval *return_value, stackdriver_debugger_snapsho
  */
 static void expressions_to_zval(zval *return_value, stackdriver_debugger_snapshot_t *snapshot)
 {
-    if (snapshot->evaluated_expressions == NULL) {
-        array_init(return_value);
-        return;
-    }
-
     ZVAL_ARR(return_value, snapshot->evaluated_expressions);
     Z_TRY_ADDREF_P(return_value);
 }
@@ -267,11 +275,9 @@ static void capture_locals(zend_execute_data *execute_data, stackdriver_debugger
     int i = 0;
     int allocated = execute_data_to_symbol_table(execute_data, &symbol_table);
 
-    stackframe->locals_count = symbol_table->nNumUsed;
-    stackframe->locals = emalloc(stackframe->locals_count * sizeof(stackdriver_debugger_variable_t*));
-
     ZEND_HASH_FOREACH_STR_KEY_VAL(symbol_table, name, value) {
-        stackframe->locals[i++] = create_variable(name, value);
+        stackdriver_debugger_variable_t *local = create_variable(name, value);
+        zend_hash_next_index_insert_ptr(stackframe->locals, local);
     } ZEND_HASH_FOREACH_END();
 
     /* Free symbol table if necessary (potential memory leak) */
@@ -344,9 +350,6 @@ int register_snapshot(zend_string *snapshot_id, zend_string *filename,
     if (expressions != NULL) {
         zval *expression;
 
-        ALLOC_HASHTABLE(snapshot->expressions);
-        zend_hash_init(snapshot->expressions, expressions->nNumUsed, NULL, ZVAL_PTR_DTOR, 0);
-
         ZEND_HASH_FOREACH_VAL(expressions, expression) {
             if (valid_debugger_statement(Z_STR_P(expression)) != SUCCESS) {
                 return FAILURE;
@@ -379,32 +382,19 @@ int register_snapshot(zend_string *snapshot_id, zend_string *filename,
 static void capture_execution_state(zend_execute_data *execute_data, stackdriver_debugger_snapshot_t *snapshot)
 {
     zend_execute_data *ptr = execute_data;
-    HashTable *backtrace;
     stackdriver_debugger_stackframe_t *stackframe;
     int i = 0;
 
-    ALLOC_HASHTABLE(backtrace);
-    zend_hash_init(backtrace, 16, NULL, ZVAL_PTR_DTOR, 0);
-
     while (ptr) {
-        stackframe = (stackdriver_debugger_stackframe_t *)emalloc(sizeof(stackdriver_debugger_stackframe_t)); // FIXME
+        stackframe = (stackdriver_debugger_stackframe_t *)emalloc(sizeof(stackdriver_debugger_stackframe_t));
+        init_stackframe(stackframe);
         if (execute_data_to_stackframe(ptr, &stackframe) == SUCCESS) {
-            zend_hash_next_index_insert_ptr(backtrace, stackframe);
+            zend_hash_next_index_insert_ptr(snapshot->stackframes, stackframe);
         } else {
             efree(stackframe);
         }
         ptr = ptr->prev_execute_data;
     }
-
-    snapshot->stackframes_count = backtrace->nNumUsed;
-    snapshot->stackframes = emalloc(snapshot->stackframes_count * sizeof(stackdriver_debugger_stackframe_t*));
-
-    ZEND_HASH_FOREACH_NUM_KEY_PTR(backtrace, i, stackframe) {
-        snapshot->stackframes[i] = stackframe;
-    } ZEND_HASH_FOREACH_END();
-
-    zend_hash_destroy(backtrace);
-    FREE_HASHTABLE(backtrace);
 }
 
 /**
@@ -415,20 +405,16 @@ static void capture_expressions(zend_execute_data *execute_data, stackdriver_deb
 {
     zval *expression;
 
-    if (snapshot->expressions) {
-        ALLOC_HASHTABLE(snapshot->evaluated_expressions);
-        zend_hash_init(snapshot->evaluated_expressions, snapshot->expressions->nNumUsed, NULL, ZVAL_PTR_DTOR, 0);
-        ZEND_HASH_FOREACH_VAL(snapshot->expressions, expression) {
-            zval retval;
+    ZEND_HASH_FOREACH_VAL(snapshot->expressions, expression) {
+        zval retval;
 
-            if (zend_eval_string(Z_STRVAL_P(expression), &retval, "expression evaluation") == SUCCESS) {
-                zend_hash_add(snapshot->evaluated_expressions, Z_STR_P(expression), &retval);
-            } else {
-                ZVAL_STRING(&retval, "ERROR");
-                zend_hash_add(snapshot->evaluated_expressions, Z_STR_P(expression), &retval);
-            }
-        } ZEND_HASH_FOREACH_END();
-    }
+        if (zend_eval_string(Z_STRVAL_P(expression), &retval, "expression evaluation") == SUCCESS) {
+            zend_hash_add(snapshot->evaluated_expressions, Z_STR_P(expression), &retval);
+        } else {
+            ZVAL_STRING(&retval, "ERROR");
+            zend_hash_add(snapshot->evaluated_expressions, Z_STR_P(expression), &retval);
+        }
+    } ZEND_HASH_FOREACH_END();
 }
 
 static int handle_snapshot_callback(zval *callback, stackdriver_debugger_snapshot_t *snapshot)

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -392,6 +392,8 @@ static void capture_execution_state(zend_execute_data *execute_data, stackdriver
         stackframe = (stackdriver_debugger_stackframe_t *)emalloc(sizeof(stackdriver_debugger_stackframe_t)); // FIXME
         if (execute_data_to_stackframe(ptr, &stackframe) == SUCCESS) {
             zend_hash_next_index_insert_ptr(backtrace, stackframe);
+        } else {
+            efree(stackframe);
         }
         ptr = ptr->prev_execute_data;
     }

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -337,6 +337,7 @@ int register_snapshot(zend_string *snapshot_id, zend_string *filename,
     snapshot->lineno = lineno;
     if (condition != NULL && ZSTR_LEN(condition) > 0) {
         if (valid_debugger_statement(condition) != SUCCESS) {
+            destroy_snapshot(snapshot);
             return FAILURE;
         }
 
@@ -347,6 +348,7 @@ int register_snapshot(zend_string *snapshot_id, zend_string *filename,
 
         ZEND_HASH_FOREACH_VAL(expressions, expression) {
             if (valid_debugger_statement(Z_STR_P(expression)) != SUCCESS) {
+                destroy_snapshot(snapshot);
                 return FAILURE;
             }
             zend_hash_next_index_insert(snapshot->expressions, expression);

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -40,8 +40,6 @@ static void destroy_variable(stackdriver_debugger_variable_t *variable)
         zend_string_release(variable->name);
     }
 
-    ZVAL_PTR_DTOR(&variable->value);
-
     efree(variable);
 }
 

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -519,8 +519,11 @@ int stackdriver_debugger_snapshot_rinit(TSRMLS_D)
 int stackdriver_debugger_snapshot_rshutdown(TSRMLS_D)
 {
     zend_hash_destroy(STACKDRIVER_DEBUGGER_G(collected_snapshots_by_id));
+    FREE_HASHTABLE(STACKDRIVER_DEBUGGER_G(collected_snapshots_by_id));
     zend_hash_destroy(STACKDRIVER_DEBUGGER_G(snapshots_by_file));
+    FREE_HASHTABLE(STACKDRIVER_DEBUGGER_G(snapshots_by_file));
     zend_hash_destroy(STACKDRIVER_DEBUGGER_G(snapshots_by_id));
+    FREE_HASHTABLE(STACKDRIVER_DEBUGGER_G(snapshots_by_id));
 
     return SUCCESS;
 }

--- a/stackdriver_debugger_snapshot.h
+++ b/stackdriver_debugger_snapshot.h
@@ -42,7 +42,7 @@ typedef struct stackdriver_debugger_snapshot_t {
     zend_string *condition;
     zend_bool fulfilled;
 
-    zval *callback;
+    zval callback;
 
     /* index => zval* (strings) */
     HashTable *expressions;

--- a/stackdriver_debugger_snapshot.h
+++ b/stackdriver_debugger_snapshot.h
@@ -29,8 +29,9 @@ typedef struct stackdriver_debugger_stackframe_t {
     zend_string *function;
     zend_string *filename;
     zend_long lineno;
-    int locals_count;
-    stackdriver_debugger_variable_t **locals;
+
+    /* list of stackdriver_debugger_variable_t */
+    HashTable *locals;
 } stackdriver_debugger_stackframe_t;
 
 /* Snapshot struct */
@@ -49,9 +50,8 @@ typedef struct stackdriver_debugger_snapshot_t {
     /* zend_string* (expression) => zval* (result) */
     HashTable *evaluated_expressions;
 
-    int stackframes_count;
-    stackdriver_debugger_stackframe_t **stackframes;
-
+    /* list of stackdriver_debugger_stackframe_t */
+    HashTable *stackframes;
 } stackdriver_debugger_snapshot_t;
 
 void evaluate_snapshot(zend_execute_data *execute_data, stackdriver_debugger_snapshot_t *snapshot);


### PR DESCRIPTION
Fixes #16.

Also fixes all of the memory leaks. Simply running the test suite under a debug version of php will fail the tests if there are memory leaks.