### PR TITLE
Both logpoint.c and snapshot.c rely on zend_exceptions.h

### DIFF
--- a/stackdriver_debugger_logpoint.c
+++ b/stackdriver_debugger_logpoint.c
@@ -18,6 +18,7 @@
 #include "php_stackdriver_debugger.h"
 #include "stackdriver_debugger_ast.h"
 #include "stackdriver_debugger_logpoint.h"
+#include "zend_exceptions.h"
 
 #if PHP_VERSION_ID < 70100
 #include "standard/php_rand.h"

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -18,6 +18,7 @@
 #include "php_stackdriver_debugger.h"
 #include "stackdriver_debugger_ast.h"
 #include "stackdriver_debugger_snapshot.h"
+#include "zend_exceptions.h"
 
 #if PHP_VERSION_ID < 70100
 #include "standard/php_rand.h"


### PR DESCRIPTION
Fixes #15

Both use `zend_clear_exception()` which is defined in `zend_exceptions.h`