### PR TITLE
Fix config.w32 for windows build

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,7 +1,7 @@
 // $Id$
 // vim:ft=javascript
 
-ARG_ENABLE("stackdriver_debugger", "stackdriver_debugger support", "no");
+ARG_WITH("stackdriver-debugger", "Stackdriver Debugger support", "no");
 
 if (PHP_STACKDRIVER_DEBUGGER != "no") {
     EXTENSION('stackdriver_debugger', 'stackdriver_debugger.c stackdriver_debugger_ast.c stackdriver_debugger_logpoint.c stackdriver_debugger_snapshot.c');

--- a/package.xml
+++ b/package.xml
@@ -18,10 +18,10 @@
   <active>yes</active>
  </lead>
  <date>2017-12-11</date>
- <time>14:17:00</time>
+ <time>17:02:00</time>
  <version>
-  <release>0.0.1</release>
-  <api>0.0.1</api>
+  <release>0.0.2</release>
+  <api>0.0.2</api>
  </version>
  <stability>
   <release>devel</release>
@@ -29,7 +29,7 @@
  </stability>
  <license>Apache 2.0</license>
  <notes>
-First dev release
+Fix windows build configuration
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">
@@ -125,6 +125,21 @@ First dev release
    <license>Apache 2.0</license>
    <notes>
 First dev release
+   </notes>
+  </release>
+  <release>
+   <version>
+    <release>0.0.2</release>
+    <api>0.0.2</api>
+   </version>
+   <stability>
+    <release>devel</release>
+    <api>devel</api>
+   </stability>
+   <date>2017-12-11</date>
+   <license>Apache 2.0</license>
+   <notes>
+Fix windows build configuration
    </notes>
   </release>
  </changelog>

--- a/php_stackdriver_debugger.h
+++ b/php_stackdriver_debugger.h
@@ -24,7 +24,7 @@
 #include "php.h"
 #include "stackdriver_debugger.h"
 
-#define PHP_STACKDRIVER_DEBUGGER_VERSION "0.0.1"
+#define PHP_STACKDRIVER_DEBUGGER_VERSION "0.0.2"
 #define PHP_STACKDRIVER_DEBUGGER_EXTNAME "stackdriver_debugger"
 #define PHP_STACKDRIVER_DEBUGGER_INI_WHITELISTED_FUNCTIONS "stackdriver_debugger.function_whitelist"
 

--- a/releases.yaml
+++ b/releases.yaml
@@ -4,3 +4,9 @@ releases:
     version: 0.0.1
     stability: devel
     notes: First dev release
+
+  - date: '2017-12-11'
+    time: 17:02:00
+    version: 0.0.2
+    stability: devel
+    notes: Fix windows build configuration


### PR DESCRIPTION
Version 0.0.2 successfully built on PECL.

The ARG_ENABLE helper doesn't like underscored/multiple name extensions