### PR TITLE
Register global whitelisted functions once at module init time

### DIFF
--- a/php_stackdriver_debugger.h
+++ b/php_stackdriver_debugger.h
@@ -43,7 +43,6 @@ PHP_RINIT_FUNCTION(stackdriver_debugger);
 PHP_RSHUTDOWN_FUNCTION(stackdriver_debugger);
 
 ZEND_BEGIN_MODULE_GLOBALS(stackdriver_debugger)
-    HashTable *whitelisted_functions;
     HashTable *user_whitelisted_functions;
 
     /* map of filename -> stackdriver_debugger_snapshot[] */

--- a/php_stackdriver_debugger.h
+++ b/php_stackdriver_debugger.h
@@ -43,6 +43,7 @@ PHP_RINIT_FUNCTION(stackdriver_debugger);
 PHP_RSHUTDOWN_FUNCTION(stackdriver_debugger);
 
 ZEND_BEGIN_MODULE_GLOBALS(stackdriver_debugger)
+    /* map of function name -> empty null zval */
     HashTable *user_whitelisted_functions;
 
     /* map of filename -> stackdriver_debugger_snapshot[] */

--- a/stackdriver_debugger_ast.c
+++ b/stackdriver_debugger_ast.c
@@ -25,6 +25,7 @@
 /* True global for storing the original zend_ast_process */
 static void (*original_zend_ast_process)(zend_ast*);
 
+/* map of function name -> empty null zval */
 static HashTable global_whitelisted_functions;
 
 /**


### PR DESCRIPTION
Fixes #11 