### PR TITLE
Support whitelisting static function calls

### DIFF
--- a/tests/function_whitelist_namespaced.phpt
+++ b/tests/function_whitelist_namespaced.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Stackdriver Debugger: Allowing a namespaced whitelisted function
+--INI--
+stackdriver_debugger.function_whitelist="foo,Foo\Bar::asdf"
+--FILE--
+<?php
+
+namespace Foo;
+
+class Bar
+{
+    public static function asdf()
+    {
+        return true;
+    }
+}
+
+$statements = [
+    'foo($bar)',
+    'bar($foo)',
+    'asdf()',
+    'Foo\Bar::asdf()',
+];
+var_dump(ini_get('stackdriver_debugger.function_whitelist'));
+
+foreach ($statements as $statement) {
+    $valid = @stackdriver_debugger_valid_statement($statement) ? 'true' : 'false';
+    echo "statement: '$statement' valid: $valid" . PHP_EOL;
+}
+
+?>
+--EXPECT--
+string(17) "foo,Foo\Bar::asdf"
+statement: 'foo($bar)' valid: true
+statement: 'bar($foo)' valid: false
+statement: 'asdf()' valid: false
+statement: 'Foo\Bar::asdf()' valid: true

--- a/tests/statement_validity.phpt
+++ b/tests/statement_validity.phpt
@@ -21,7 +21,8 @@ $statements = [
     // whitelisted function
     'count(array([])) == 0',
     'count([]) == 0',
-    'count(array_keys([])) == 0'
+    'count(array_keys([])) == 0',
+    'Foo\Bar::asdf()',
 ];
 
 foreach ($statements as $statement) {
@@ -47,3 +48,4 @@ statement: 'asdf->foo;' valid: false
 statement: 'count(array([])) == 0' valid: true
 statement: 'count([]) == 0' valid: true
 statement: 'count(array_keys([])) == 0' valid: true
+statement: 'Foo\Bar::asdf()' valid: false


### PR DESCRIPTION
We still won't allow method calls because we don't know what type of value the object is until runtime.