### PR TITLE
Fix missing snapshot when using OPCache

### DIFF
--- a/stackdriver_debugger.c
+++ b/stackdriver_debugger.c
@@ -226,11 +226,7 @@ PHP_FUNCTION(stackdriver_debugger_snapshot)
     start = stackdriver_debugger_now();
     snapshot = zend_hash_find_ptr(STACKDRIVER_DEBUGGER_G(snapshots_by_id), snapshot_id);
 
-    if (snapshot->fulfilled) {
-        RETURN_FALSE;
-    }
-
-    if (snapshot == NULL || test_conditional(snapshot->condition) != SUCCESS) {
+    if (snapshot == NULL || snapshot->fulfilled || test_conditional(snapshot->condition) != SUCCESS) {
         STACKDRIVER_DEBUGGER_G(time_spent) = STACKDRIVER_DEBUGGER_G(time_spent) + stackdriver_debugger_now() - start;
         RETURN_FALSE;
     }

--- a/tests/logpoints/missing_logpoint_id.phpt
+++ b/tests/logpoints/missing_logpoint_id.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Stackdriver Debugger: Executing non-existent breakpoint is a no-op
+--FILE--
+<?php
+
+var_dump(stackdriver_debugger_logpoint('non-existent-id'));
+--EXPECT--
+bool(false)

--- a/tests/snapshots/missing_snapshot_id.phpt
+++ b/tests/snapshots/missing_snapshot_id.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Stackdriver Debugger: Executing non-existent breakpoint is a no-op
+--FILE--
+<?php
+
+var_dump(stackdriver_debugger_snapshot('non-existent-id'));
+--EXPECT--
+bool(false)


### PR DESCRIPTION
This error happens when OPCache is enabled and the snapshot is no longer present. The AST has reference to a no longer existing breakpoint id.