### PR TITLE
Limit time spent in debugger to 1% of request time

### DIFF
--- a/php_stackdriver_debugger.h
+++ b/php_stackdriver_debugger.h
@@ -66,6 +66,7 @@ ZEND_BEGIN_MODULE_GLOBALS(stackdriver_debugger)
 
     double time_spent;
     double max_time;
+    double request_start;
 
 ZEND_END_MODULE_GLOBALS(stackdriver_debugger)
 

--- a/php_stackdriver_debugger.h
+++ b/php_stackdriver_debugger.h
@@ -28,6 +28,7 @@
 #define PHP_STACKDRIVER_DEBUGGER_EXTNAME "stackdriver_debugger"
 #define PHP_STACKDRIVER_DEBUGGER_INI_WHITELISTED_FUNCTIONS "stackdriver_debugger.function_whitelist"
 #define PHP_STACKDRIVER_DEBUGGER_INI_MAX_TIME "stackdriver_debugger.max_time"
+#define PHP_STACKDRIVER_DEBUGGER_INI_MAX_TIME_PERCENTAGE "stackdriver_debugger.max_time_percentage"
 
 PHP_FUNCTION(stackdriver_debugger_version);
 
@@ -65,7 +66,6 @@ ZEND_BEGIN_MODULE_GLOBALS(stackdriver_debugger)
     HashTable *ast_to_clean;
 
     double time_spent;
-    double max_time;
     double request_start;
 
 ZEND_END_MODULE_GLOBALS(stackdriver_debugger)

--- a/stackdriver_debugger.c
+++ b/stackdriver_debugger.c
@@ -63,7 +63,6 @@ static zend_function_entry stackdriver_debugger_functions[] = {
     PHP_FE(stackdriver_debugger_add_logpoint, arginfo_stackdriver_debugger_add_logpoint)
     PHP_FE(stackdriver_debugger_list_logpoints, NULL)
     PHP_FE(stackdriver_debugger_valid_statement, arginfo_stackdriver_debugger_valid_statement)
-    PHP_FE(stackdriver_debugger_usage, NULL)
     PHP_FE_END
 };
 
@@ -375,14 +374,6 @@ PHP_FUNCTION(stackdriver_debugger_add_snapshot)
     zend_string_release(full_filename);
 
     RETURN_TRUE;
-}
-
-PHP_FUNCTION(stackdriver_debugger_usage)
-{
-    array_init(return_value);
-    add_next_index_double(return_value, stackdriver_debugger_total_time_spent);
-    add_next_index_long(return_value, stackdriver_debugger_total_requests_handled);
-    add_next_index_double(return_value, stackdriver_debugger_max_time());
 }
 
 /**

--- a/stackdriver_debugger.c
+++ b/stackdriver_debugger.c
@@ -512,7 +512,7 @@ PHP_RSHUTDOWN_FUNCTION(stackdriver_debugger)
     stackdriver_debugger_snapshot_rshutdown(TSRMLS_C);
     stackdriver_debugger_logpoint_rshutdown(TSRMLS_C);
 
-    stackdriver_debugger_total_time_spent += stackdriver_debugger_now() - STACKDRIVER_DEBUGGER_G(request_start);
+    stackdriver_debugger_total_time_spent += stackdriver_debugger_now() - STACKDRIVER_DEBUGGER_G(request_start) - STACKDRIVER_DEBUGGER_G(time_spent);
     stackdriver_debugger_total_requests_handled++;
 
     return SUCCESS;

--- a/stackdriver_debugger.h
+++ b/stackdriver_debugger.h
@@ -27,6 +27,5 @@ PHP_FUNCTION(stackdriver_debugger_logpoint);
 PHP_FUNCTION(stackdriver_debugger_add_logpoint);
 PHP_FUNCTION(stackdriver_debugger_list_logpoints);
 PHP_FUNCTION(stackdriver_debugger_valid_statement);
-PHP_FUNCTION(stackdriver_debugger_usage);
 
 #endif

--- a/stackdriver_debugger.h
+++ b/stackdriver_debugger.h
@@ -27,5 +27,6 @@ PHP_FUNCTION(stackdriver_debugger_logpoint);
 PHP_FUNCTION(stackdriver_debugger_add_logpoint);
 PHP_FUNCTION(stackdriver_debugger_list_logpoints);
 PHP_FUNCTION(stackdriver_debugger_valid_statement);
+PHP_FUNCTION(stackdriver_debugger_usage);
 
 #endif


### PR DESCRIPTION
Fixes #5 

The extension keeps a rudimentary measure of time spent on a request (minus any time spent in the debugger) as well as a request count in order to track average request response time. For the time limit for snapshots/logpoints, we limit to the lesser value of 10ms or x% of the average request response time.

The x% is configurable via the `stackdriver_debugger.max_time_percentage` `php.ini` config value and defaults to `1`.