### PR TITLE
Limit captured variable depth

### DIFF
--- a/stackdriver_debugger.c
+++ b/stackdriver_debugger.c
@@ -26,8 +26,6 @@
 #include "stackdriver_debugger_time_functions.h"
 #include "zend_alloc.h"
 
-#define DEFAULT_MAX_STACK_EVAL_DEPTH 5
-
 ZEND_DECLARE_MODULE_GLOBALS(stackdriver_debugger)
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_stackdriver_debugger_snapshot, 0, 0, 1)
@@ -347,7 +345,7 @@ static zend_string *stackdriver_debugger_full_filename(zend_string *relative_or_
  *      @type callable $callback The callback to execute when the snapshot is
  *            hit.
  *      @type int $maxDepth The maximum number of stackframes whose variables
- *            are captured. **Defaults to** DEFAULT_MAX_STACK_EVAL_DEPTH.
+ *            are captured. If 0, then no limit. **Defaults to** 0.
  * }
  */
 PHP_FUNCTION(stackdriver_debugger_add_snapshot)
@@ -356,7 +354,7 @@ PHP_FUNCTION(stackdriver_debugger_add_snapshot)
     zend_long lineno;
     HashTable *options = NULL, *expressions = NULL;
     zval *zv = NULL, *callback = NULL;
-    zend_long max_stack_eval_depth = DEFAULT_MAX_STACK_EVAL_DEPTH;
+    zend_long max_stack_eval_depth = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Sl|h", &filename, &lineno, &options) == FAILURE) {
         RETURN_FALSE;

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -392,7 +392,7 @@ static void capture_execution_state(zend_execute_data *execute_data, stackdriver
     int i = 0;
 
     while (ptr) {
-        if (i < snapshot->max_stack_eval_depth) {
+        if (snapshot->max_stack_eval_depth == 0 || i < snapshot->max_stack_eval_depth) {
             stackframe = execute_data_to_stackframe(ptr, 1);
         } else {
             stackframe = execute_data_to_stackframe(ptr, 0);

--- a/stackdriver_debugger_snapshot.h
+++ b/stackdriver_debugger_snapshot.h
@@ -41,6 +41,7 @@ typedef struct stackdriver_debugger_snapshot_t {
     zend_long lineno;
     zend_string *condition;
     zend_bool fulfilled;
+    zend_long max_stack_eval_depth;
 
     zval callback;
 
@@ -56,8 +57,7 @@ typedef struct stackdriver_debugger_snapshot_t {
 
 void evaluate_snapshot(zend_execute_data *execute_data, stackdriver_debugger_snapshot_t *snapshot);
 void list_snapshots(zval *return_value);
-int register_snapshot(zend_string *snapshot_id, zend_string *filename, zend_long lineno, zend_string *condition, HashTable *expressions, zval *callback);
-
+int register_snapshot(zend_string *snapshot_id, zend_string *filename, zend_long lineno, zend_string *condition, HashTable *expressions, zval *callback, zend_long max_stack_eval_depth);
 /* request lifecycle callbacks */
 int stackdriver_debugger_snapshot_rinit(TSRMLS_D);
 int stackdriver_debugger_snapshot_rshutdown(TSRMLS_D);

--- a/tests/snapshots/deep.php
+++ b/tests/snapshots/deep.php
@@ -1,0 +1,39 @@
+<?php
+
+// this test file enables setting a deep function stack
+
+function depth1()
+{
+    $val = 1;
+    return $val;
+}
+
+function depth2()
+{
+    $val = depth1() + 1;
+    return $val;
+}
+
+function depth3()
+{
+    $val = depth2() + 1;
+    return $val;
+}
+
+function depth4()
+{
+    $val = depth3() + 1;
+    return $val;
+}
+
+function depth5()
+{
+    $val = depth4() + 1;
+    return $val;
+}
+
+function depth6()
+{
+    $val = depth5() + 1;
+    return $val;
+}

--- a/tests/snapshots/maximum_stack_frames.phpt
+++ b/tests/snapshots/maximum_stack_frames.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Stackdriver Debugger: Snapshot stackframe limit should default to 5
+--FILE--
+<?php
+
+var_dump(stackdriver_debugger_add_snapshot('deep.php', 8));
+
+require_once(__DIR__ . '/deep.php');
+
+$depth = depth6();
+var_dump($depth);
+
+$list = stackdriver_debugger_list_snapshots();
+echo "Number of breakpoints: " . count($list) . PHP_EOL;
+
+$breakpoint = $list[0];
+// var_dump($breakpoint['stackframes']);
+echo "Number of stackframes: " . count($breakpoint['stackframes']) . PHP_EOL;
+
+$i = 0;
+foreach($breakpoint['stackframes'] as $stackframe) {
+    $variableCount = count($stackframe['locals']);
+    echo "Level $i: $variableCount variables\n";
+    $i++;
+}
+
+?>
+--EXPECTF--
+bool(true)
+int(6)
+Number of breakpoints: 1
+Number of stackframes: 7
+Level 0: 1 variables
+Level 1: 1 variables
+Level 2: 1 variables
+Level 3: 1 variables
+Level 4: 1 variables
+Level 5: 0 variables
+Level 6: 0 variables

--- a/tests/snapshots/maximum_stack_frames_configure.phpt
+++ b/tests/snapshots/maximum_stack_frames_configure.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Stackdriver Debugger: Snapshot stackframe limit should be configurable
+--FILE--
+<?php
+
+var_dump(stackdriver_debugger_add_snapshot('deep.php', 8, [
+    'maxDepth' => 3
+]));
+
+require_once(__DIR__ . '/deep.php');
+
+$depth = depth6();
+var_dump($depth);
+
+$list = stackdriver_debugger_list_snapshots();
+echo "Number of breakpoints: " . count($list) . PHP_EOL;
+
+$breakpoint = $list[0];
+// var_dump($breakpoint['stackframes']);
+echo "Number of stackframes: " . count($breakpoint['stackframes']) . PHP_EOL;
+
+$i = 0;
+foreach($breakpoint['stackframes'] as $stackframe) {
+    $variableCount = count($stackframe['locals']);
+    echo "Level $i: $variableCount variables\n";
+    $i++;
+}
+
+?>
+--EXPECTF--
+bool(true)
+int(6)
+Number of breakpoints: 1
+Number of stackframes: 7
+Level 0: 1 variables
+Level 1: 1 variables
+Level 2: 1 variables
+Level 3: 0 variables
+Level 4: 0 variables
+Level 5: 0 variables
+Level 6: 0 variables

--- a/tests/snapshots/maximum_stack_frames_configure_all.phpt
+++ b/tests/snapshots/maximum_stack_frames_configure_all.phpt
@@ -1,9 +1,11 @@
 --TEST--
-Stackdriver Debugger: Snapshot stackframe limit should default to all frames
+Stackdriver Debugger: Snapshot stackframe limit of 0 should capture all frames
 --FILE--
 <?php
 
-var_dump(stackdriver_debugger_add_snapshot('deep.php', 8));
+var_dump(stackdriver_debugger_add_snapshot('deep.php', 8,[
+    'maxDepth' => 0
+]));
 
 require_once(__DIR__ . '/deep.php');
 


### PR DESCRIPTION
Limit the number of stackframes where we capture local variable state.

Other languages' agents limit the number of stackframes. The extension will defer the limit number to the PHP library via the options array when registering a snapshot.