### PR TITLE
Provide array and string identifier to allow deduping values

### DIFF
--- a/tests/snapshots/capture_array.phpt
+++ b/tests/snapshots/capture_array.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Stackdriver Debugger: Basic variable dump
+--FILE--
+<?php
+
+var_dump(stackdriver_debugger_add_snapshot('echo.php', 4));
+
+require_once(__DIR__ . '/echo.php');
+
+$input = [1, 2, "foo", "bar", [1, 2]];
+$output = echoValue($input);
+
+$list = stackdriver_debugger_list_snapshots();
+
+echo "Number of breakpoints: " . count($list) . PHP_EOL;
+
+$breakpoint = $list[0];
+echo "Number of stackframes: " . count($breakpoint['stackframes']) . PHP_EOL;
+$echoVariables = $breakpoint['stackframes'][0]['locals'];
+$rootVariables = $breakpoint['stackframes'][1]['locals'];
+
+$count = count($echoVariables);
+echo "function has $count variables" . PHP_EOL;
+$array = $echoVariables[0];
+$test = array_key_exists('id', $array);
+echo "function variable has id: $test" . PHP_EOL;
+
+// Find the 'input' variable
+$inputVar = null;
+foreach ($rootVariables as $local) {
+    if ($local['name'] == 'input') {
+        $inputVar = $local;
+        break;
+    }
+}
+$test = $inputVar['id'] == $array['id'];
+echo "root value has same id as function value id: $test" . PHP_EOL;
+
+?>
+--EXPECTF--
+bool(true)
+Number of breakpoints: 1
+Number of stackframes: 2
+function has 1 variables
+function variable has id: 1
+root value has same id as function value id: 1

--- a/tests/snapshots/capture_object.phpt
+++ b/tests/snapshots/capture_object.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Stackdriver Debugger: Capturing an array should return a hash id
+Stackdriver Debugger: Capturing an object should return a hash id
 --FILE--
 <?php
 
@@ -7,9 +7,18 @@ var_dump(stackdriver_debugger_add_snapshot('echo.php', 4));
 
 require_once(__DIR__ . '/echo.php');
 
-$input = [1, 2, "foo", "bar", [1, 2]];
-$output = echoValue($input);
+class Foo
+{
+    public $bar;
 
+    public function __construct($bar)
+    {
+        $this->bar = $bar;
+    }
+}
+
+$input = new Foo('asdf');
+$output = echoValue($input);
 $list = stackdriver_debugger_list_snapshots();
 
 echo "Number of breakpoints: " . count($list) . PHP_EOL;

--- a/tests/snapshots/capture_string.phpt
+++ b/tests/snapshots/capture_string.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Stackdriver Debugger: Capturing an array should return a hash id
+Stackdriver Debugger: Capturing a string should return a hash id
 --FILE--
 <?php
 
@@ -7,9 +7,8 @@ var_dump(stackdriver_debugger_add_snapshot('echo.php', 4));
 
 require_once(__DIR__ . '/echo.php');
 
-$input = [1, 2, "foo", "bar", [1, 2]];
+$input = "Hello, World!";
 $output = echoValue($input);
-
 $list = stackdriver_debugger_list_snapshots();
 
 echo "Number of breakpoints: " . count($list) . PHP_EOL;

--- a/tests/snapshots/echo.php
+++ b/tests/snapshots/echo.php
@@ -1,0 +1,5 @@
+<?php
+
+function echoValue($value) {
+    return $value;
+}


### PR DESCRIPTION
Fixes #40 

We should be able to utilize the VariableTable feature for objects, arrays, and strings if we can recognize when they are identical. For objects, we are already using `spl_object_hash` from the PHP library. For arrays and strings, we do not have an id to cross reference against variables already seen for this breakpoint.

When returning a captured variable to the PHP library, we will now optionally provide an `id` hash string that will identify arrays and strings with a uniquifier.