### PR TITLE
Change ZVAL_DESTRUCTOR to zval_ptr_dtor to run on PHP 7.3

### DIFF
--- a/stackdriver_debugger_logpoint.c
+++ b/stackdriver_debugger_logpoint.c
@@ -80,7 +80,7 @@ static void destroy_logpoint(stackdriver_debugger_logpoint_t *logpoint)
     FREE_HASHTABLE(logpoint->expressions);
 
     if (Z_TYPE(logpoint->callback) != IS_NULL) {
-        ZVAL_DESTRUCTOR(&logpoint->callback);
+        zval_ptr_dtor(&logpoint->callback);
     }
 
     efree(logpoint);
@@ -101,7 +101,7 @@ static void destroy_message(stackdriver_debugger_message_t *message)
 {
     zend_string_release(message->filename);
     zend_string_release(message->log_level);
-    ZVAL_DESTRUCTOR(&message->message);
+    zval_ptr_dtor(&message->message);
 
     efree(message);
 }
@@ -117,16 +117,16 @@ static int handle_message_callback(zval *callback, stackdriver_debugger_message_
     add_assoc_long(&args[2], "line", message->lineno);
 
     if (call_user_function_ex(EG(function_table), NULL, callback, &callback_result, 3, args, 0, NULL) != SUCCESS) {
-        ZVAL_DESTRUCTOR(&args[0]);
-        ZVAL_DESTRUCTOR(&args[1]);
-        ZVAL_DESTRUCTOR(&args[2]);
-        ZVAL_DESTRUCTOR(&callback_result);
+        zval_ptr_dtor(&args[0]);
+        zval_ptr_dtor(&args[1]);
+        zval_ptr_dtor(&args[2]);
+        zval_ptr_dtor(&callback_result);
         return FAILURE;
     }
-    ZVAL_DESTRUCTOR(&args[0]);
-    ZVAL_DESTRUCTOR(&args[1]);
-    ZVAL_DESTRUCTOR(&args[2]);
-    ZVAL_DESTRUCTOR(&callback_result);
+    zval_ptr_dtor(&args[0]);
+    zval_ptr_dtor(&args[1]);
+    zval_ptr_dtor(&args[2]);
+    zval_ptr_dtor(&callback_result);
     return SUCCESS;
 }
 
@@ -161,7 +161,7 @@ void evaluate_logpoint(zend_execute_data *execute_data, stackdriver_debugger_log
                 zend_string_release(regex);
                 m = replaced;
             }
-            ZVAL_DESTRUCTOR(&retval);
+            zval_ptr_dtor(&retval);
         } ZEND_HASH_FOREACH_END();
     }
     ZVAL_STR(&message->message, m);

--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -122,7 +122,7 @@ static void destroy_snapshot(stackdriver_debugger_snapshot_t *snapshot)
     FREE_HASHTABLE(snapshot->stackframes);
 
     if (Z_TYPE(snapshot->callback) != IS_NULL) {
-        ZVAL_DESTRUCTOR(&snapshot->callback);
+        zval_ptr_dtor(&snapshot->callback);
     }
     efree(snapshot);
 }
@@ -440,8 +440,8 @@ static int handle_snapshot_callback(zval *callback, stackdriver_debugger_snapsho
     snapshot_to_zval(&zsnapshot, snapshot);
     int call_result = call_user_function_ex(EG(function_table), NULL, callback, &callback_result, 1, &zsnapshot, 0, NULL);
 
-    ZVAL_DESTRUCTOR(&zsnapshot);
-    ZVAL_DESTRUCTOR(&callback_result);
+    zval_ptr_dtor(&zsnapshot);
+    zval_ptr_dtor(&callback_result);
     return call_result;
 }
 


### PR DESCRIPTION
To compile on PHP 7.3, the deprecated `ZVAL_DESTRUCTOR` macro must be exchanged with `zval_ptr_dtor`.