### PR TITLE
Better handling of the evaluation of invalid expressions

### DIFF
--- a/stackdriver_debugger_snapshot.c
+++ b/stackdriver_debugger_snapshot.c
@@ -425,12 +425,12 @@ static void capture_expressions(zend_execute_data *execute_data, stackdriver_deb
     ZEND_HASH_FOREACH_VAL(snapshot->expressions, expression) {
         zval retval;
 
-        if (zend_eval_string(Z_STRVAL_P(expression), &retval, "expression evaluation") == SUCCESS) {
-            zend_hash_add(snapshot->evaluated_expressions, Z_STR_P(expression), &retval);
-        } else {
-            ZVAL_STRING(&retval, "ERROR");
-            zend_hash_add(snapshot->evaluated_expressions, Z_STR_P(expression), &retval);
+        if (zend_eval_string(Z_STRVAL_P(expression), &retval, "expression evaluation") != SUCCESS ||
+            EG(exception) != NULL) {
+            zend_clear_exception();
+            ZVAL_STRING(&retval, "ERROR IN EXPRESSION");
         }
+        zend_hash_add(snapshot->evaluated_expressions, Z_STR_P(expression), &retval);
     } ZEND_HASH_FOREACH_END();
 }
 

--- a/tests/logpoints/expressions_invalid.phpt
+++ b/tests/logpoints/expressions_invalid.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Stackdriver Debugger: Invalid Expressions in logpoints should be replaced by an error message
+--FILE--
+<?php
+set_error_handler(function(int $number, string $message) {
+   throw new \Error('Error')  ;
+});
+
+// set a snapshot for line 12 in loop.php (return $sum)
+var_dump(stackdriver_debugger_add_logpoint('loop.php', 12, 'INFO', 'Logpoint hit! 0: $0', [
+    'expressions' => [
+        '$times->foo == 4'
+    ]
+]));
+
+require_once(__DIR__ . '/loop.php');
+
+$sum = loop(10);
+
+echo "Sum is {$sum}\n";
+
+$logpoints = stackdriver_debugger_list_logpoints();
+
+echo "Number of logpoints: " . count($logpoints) . PHP_EOL;
+
+var_dump(array_map(function ($logpoint) {
+    return $logpoint['message'];
+}, $logpoints))
+?>
+--EXPECTF--
+bool(true)
+Sum is 45
+Number of logpoints: 1
+array(1) {
+  [0]=>
+  string(40) "Logpoint hit! 0: {ERROR IN EXPRESSION 0}"
+}

--- a/tests/snapshots/expressions_invalid.phpt
+++ b/tests/snapshots/expressions_invalid.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Stackdriver Debugger: Warnings in expressions will display.
+--FILE--
+<?php
+set_error_handler(function(int $number, string $message) {
+   throw new \Error('Error')  ;
+});
+
+// set a snapshot for line 7 in loop.php ($sum += $i)
+var_dump(stackdriver_debugger_add_snapshot('loop.php', 7, [
+    'expressions' => [
+        '$times->foo == 4'
+    ]
+]));
+
+require_once(__DIR__ . '/loop.php');
+
+$sum = loop(4);
+
+echo "Sum is {$sum}\n";
+
+$list = stackdriver_debugger_list_snapshots();
+
+echo "Number of breakpoints: " . count($list) . PHP_EOL;
+$breakpoint = $list[0];
+var_dump($breakpoint['evaluatedExpressions']);
+?>
+--EXPECTF--
+bool(true)
+Sum is 6
+Number of breakpoints: 1
+array(1) {
+  ["$times->foo == 4"]=>
+  string(19) "ERROR IN EXPRESSION"
+}


### PR DESCRIPTION
If when evaluating an expression in a logpoint or snapshot it throws and Error or Exception, catch that so that the application is not broken by the breakpoint, logging or capturing an error message instead

Fixes #49

All existing tests are passing and Includes some new tests for the new functionality