### PR TITLE
Allow whitelisting class methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,26 @@ ini_set('stackdriver_debugger.function_whitelist', 'foo,bar,MyClass::function');
 Note that all function names specified here must be declared with their full
 namespace if applicable.
 
+This setting applies to global functions, not to methods of classes.
+
+### Whitelisting Method Calls in Conditions and Evaluated Expressions
+
+By default no method calls are allowed on any class or object
+
+You can add a list of method calls that will be allowed on any class or object by setting the ini config
+`stackdriver_debugger.method_whitelist`:
+
+```
+# in php.ini
+stackdriver_debugger.method_whitelist="getId,isDeleted"
+```
+
+```php
+ini_set('stackdriver_debugger.method_whitelist', 'getId,isDeleted');
+```
+
+Note that this list is applied to any class or object, so make sure that the methods in this list do not produce any side effects for any class. This setting does not apply to static methods which should be specified in the global function whitelist with their full namespace.
+
 ## Design
 
 For more information on the design of this project, see

--- a/php_stackdriver_debugger.h
+++ b/php_stackdriver_debugger.h
@@ -27,6 +27,7 @@
 #define PHP_STACKDRIVER_DEBUGGER_VERSION "0.2.0"
 #define PHP_STACKDRIVER_DEBUGGER_EXTNAME "stackdriver_debugger"
 #define PHP_STACKDRIVER_DEBUGGER_INI_WHITELISTED_FUNCTIONS "stackdriver_debugger.function_whitelist"
+#define PHP_STACKDRIVER_DEBUGGER_INI_WHITELISTED_METHODS "stackdriver_debugger.method_whitelist"
 #define PHP_STACKDRIVER_DEBUGGER_INI_MAX_TIME "stackdriver_debugger.max_time"
 #define PHP_STACKDRIVER_DEBUGGER_INI_MAX_TIME_PERCENTAGE "stackdriver_debugger.max_time_percentage"
 #define PHP_STACKDRIVER_DEBUGGER_INI_MAX_MEMORY "stackdriver_debugger.max_memory"
@@ -44,6 +45,9 @@ PHP_RSHUTDOWN_FUNCTION(stackdriver_debugger);
 ZEND_BEGIN_MODULE_GLOBALS(stackdriver_debugger)
     /* map of function name -> empty null zval */
     HashTable *user_whitelisted_functions;
+
+    /* map of method name -> empty null zval */
+    HashTable *user_whitelisted_methods;
 
     /* map of filename -> stackdriver_debugger_snapshot[] */
     HashTable *snapshots_by_file;

--- a/stackdriver_debugger.c
+++ b/stackdriver_debugger.c
@@ -101,6 +101,7 @@ PHP_INI_MH(OnUpdate_stackdriver_debugger_max_memory);
 /* Registers php.ini directives */
 PHP_INI_BEGIN()
     PHP_INI_ENTRY(PHP_STACKDRIVER_DEBUGGER_INI_WHITELISTED_FUNCTIONS, NULL, PHP_INI_ALL, OnUpdate_stackdriver_debugger_whitelisted_functions)
+    PHP_INI_ENTRY(PHP_STACKDRIVER_DEBUGGER_INI_WHITELISTED_METHODS, NULL, PHP_INI_ALL, OnUpdate_stackdriver_debugger_whitelisted_methods)
     PHP_INI_ENTRY(PHP_STACKDRIVER_DEBUGGER_INI_MAX_TIME, "10", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY(PHP_STACKDRIVER_DEBUGGER_INI_MAX_TIME_PERCENTAGE, "1", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY(PHP_STACKDRIVER_DEBUGGER_INI_MAX_MEMORY, "10", PHP_INI_ALL, OnUpdate_stackdriver_debugger_max_memory)

--- a/stackdriver_debugger_ast.h
+++ b/stackdriver_debugger_ast.h
@@ -29,5 +29,6 @@ void stackdriver_list_breakpoint_ids(zval *return_value);
 int stackdriver_debugger_breakpoint_injected(zend_string *filename, zend_string *breakpoint_id);
 
 PHP_INI_MH(OnUpdate_stackdriver_debugger_whitelisted_functions);
+PHP_INI_MH(OnUpdate_stackdriver_debugger_whitelisted_methods);
 
 #endif /* PHP_STACKDRIVER_DEBUGGER_AST_H */

--- a/tests/function_whitelist.phpt
+++ b/tests/function_whitelist.phpt
@@ -1,7 +1,8 @@
 --TEST--
-Stackdriver Debugger: Allowing a whitelisted function
+Stackdriver Debugger: Allowing a whitelisted function and a whitelisted method
 --INI--
 stackdriver_debugger.function_whitelist="foo"
+stackdriver_debugger.method_whitelist="bar"
 --FILE--
 <?php
 
@@ -9,8 +10,12 @@ $statements = [
     'foo($bar)',
     'bar($foo)',
     'asdf()',
+    '$foo->bar()',
+    '$bar->foo()',
+    '$foo->asdf()',
 ];
 var_dump(ini_get('stackdriver_debugger.function_whitelist'));
+var_dump(ini_get('stackdriver_debugger.method_whitelist'));
 
 foreach ($statements as $statement) {
     $valid = @stackdriver_debugger_valid_statement($statement) ? 'true' : 'false';
@@ -20,6 +25,10 @@ foreach ($statements as $statement) {
 ?>
 --EXPECT--
 string(3) "foo"
+string(3) "bar"
 statement: 'foo($bar)' valid: true
 statement: 'bar($foo)' valid: false
 statement: 'asdf()' valid: false
+statement: '$foo->bar()' valid: true
+statement: '$bar->foo()' valid: false
+statement: '$foo->asdf()' valid: false

--- a/tests/function_whitelist_ini_set.phpt
+++ b/tests/function_whitelist_ini_set.phpt
@@ -1,16 +1,21 @@
 --TEST--
-Stackdriver Debugger: Allowing a whitelisted function from ini_set
+Stackdriver Debugger: Allowing a whitelisted function and a whitelisted method from ini_set
 --FILE--
 <?php
 
 ini_set('stackdriver_debugger.function_whitelist', 'foo');
+ini_set('stackdriver_debugger.method_whitelist', 'bar');
 
 $statements = [
     'foo($bar)',
     'bar($foo)',
     'asdf()',
+    '$foo->bar()',
+    '$bar->foo()',
+    '$foo->asdf()',
 ];
 var_dump(ini_get('stackdriver_debugger.function_whitelist'));
+var_dump(ini_get('stackdriver_debugger.method_whitelist'));
 
 foreach ($statements as $statement) {
     $valid = @stackdriver_debugger_valid_statement($statement) ? 'true' : 'false';
@@ -20,6 +25,10 @@ foreach ($statements as $statement) {
 ?>
 --EXPECT--
 string(3) "foo"
+string(3) "bar"
 statement: 'foo($bar)' valid: true
 statement: 'bar($foo)' valid: false
 statement: 'asdf()' valid: false
+statement: '$foo->bar()' valid: true
+statement: '$bar->foo()' valid: false
+statement: '$foo->asdf()' valid: false

--- a/tests/function_whitelist_multiple.phpt
+++ b/tests/function_whitelist_multiple.phpt
@@ -1,16 +1,24 @@
 --TEST--
-Stackdriver Debugger: Allowing multiple whitelisted functions
+Stackdriver Debugger: Allowing multiple whitelisted functions and methods
 --INI--
 stackdriver_debugger.function_whitelist="foo,bar"
+stackdriver_debugger.method_whitelist="one,two"
 --FILE--
 <?php
 
 $statements = [
     'foo($bar)',
     'bar($foo)',
+    'one($two)',
+    'two($one)',
     'asdf()',
+    '$obj->foo($bar)',
+    '$obj->bar($foo)',
+    '$obj->one($two)',
+    '$obj->two($one)',
 ];
 var_dump(ini_get('stackdriver_debugger.function_whitelist'));
+var_dump(ini_get('stackdriver_debugger.method_whitelist'));
 
 foreach ($statements as $statement) {
     $valid = @stackdriver_debugger_valid_statement($statement) ? 'true' : 'false';
@@ -20,6 +28,13 @@ foreach ($statements as $statement) {
 ?>
 --EXPECT--
 string(7) "foo,bar"
+string(7) "one,two"
 statement: 'foo($bar)' valid: true
 statement: 'bar($foo)' valid: true
+statement: 'one($two)' valid: false
+statement: 'two($one)' valid: false
 statement: 'asdf()' valid: false
+statement: '$obj->foo($bar)' valid: false
+statement: '$obj->bar($foo)' valid: false
+statement: '$obj->one($two)' valid: true
+statement: '$obj->two($one)' valid: true

--- a/tests/function_whitelist_namespaced.phpt
+++ b/tests/function_whitelist_namespaced.phpt
@@ -1,7 +1,8 @@
 --TEST--
-Stackdriver Debugger: Allowing a namespaced whitelisted function
+Stackdriver Debugger: Allowing a namespaced whitelisted function. Namespaced methods should not be allowed
 --INI--
 stackdriver_debugger.function_whitelist="foo,Foo\Bar::asdf"
+stackdriver_debugger.method_whitelist="one,One\Two::hjkl"
 --FILE--
 <?php
 
@@ -20,8 +21,15 @@ $statements = [
     'bar($foo)',
     'asdf()',
     'Foo\Bar::asdf()',
+    'One\Two::hjkl()',
+    '$obj->one($two)',
+    '$obj->two($one)',
+    '$obj->hjkl()',
+    '$obj->One\Two::hjkl()',
+    '$obj->Foo\Bar::asdf()',
 ];
 var_dump(ini_get('stackdriver_debugger.function_whitelist'));
+var_dump(ini_get('stackdriver_debugger.method_whitelist'));
 
 foreach ($statements as $statement) {
     $valid = @stackdriver_debugger_valid_statement($statement) ? 'true' : 'false';
@@ -31,7 +39,14 @@ foreach ($statements as $statement) {
 ?>
 --EXPECT--
 string(17) "foo,Foo\Bar::asdf"
+string(17) "one,One\Two::hjkl"
 statement: 'foo($bar)' valid: true
 statement: 'bar($foo)' valid: false
 statement: 'asdf()' valid: false
 statement: 'Foo\Bar::asdf()' valid: true
+statement: 'One\Two::hjkl()' valid: false
+statement: '$obj->one($two)' valid: true
+statement: '$obj->two($one)' valid: false
+statement: '$obj->hjkl()' valid: false
+statement: '$obj->One\Two::hjkl()' valid: false
+statement: '$obj->Foo\Bar::asdf()' valid: false

--- a/tests/statement_validity.phpt
+++ b/tests/statement_validity.phpt
@@ -23,6 +23,8 @@ $statements = [
     'count([]) == 0',
     'count(array_keys([])) == 0',
     'Foo\Bar::asdf()',
+    '$foo->bar()',
+    '$foo->asdf()',
 ];
 
 foreach ($statements as $statement) {
@@ -49,3 +51,5 @@ statement: 'count(array([])) == 0' valid: true
 statement: 'count([]) == 0' valid: true
 statement: 'count(array_keys([])) == 0' valid: true
 statement: 'Foo\Bar::asdf()' valid: false
+statement: '$foo->bar()' valid: false
+statement: '$foo->asdf()' valid: false


### PR DESCRIPTION
In most modern PHP applications the majority of class fields will be private or protected and there will be a set of getters to access those fields. This makes it difficult to use expressions in snapshots or logpoints because many times the information that interests you will be held in a private or protected field, so you will not be able to use a expression like `$object->privateMember` because you will not have access. By default you cannot call any method in an object and there is no way to whitelist method calls.

In this PR we add a new PHP ini setting `stackdriver_debugger.method_whitelist` that will allow you to whitelist a list of class methods. This provides us with a way to whitelist method calls so that we can use expressions like `$object->getPrivateMember()`. By default no method call is allowed but if we know that some of them are safe we should be able to whitelist them, the same way that we do for generic functions using the `stackdriver_debugger.function_whitelist`

Fixes #51 
