### PR TITLE
Confirm that the hashes have been initialised before trying to use them

### DIFF
--- a/stackdriver_debugger_ast.c
+++ b/stackdriver_debugger_ast.c
@@ -295,8 +295,14 @@ void stackdriver_debugger_ast_process(zend_ast *ast)
     zend_ast_list *to_insert;
     zend_string *filename = zend_get_compiled_filename();
 
-    zval *snapshots = zend_hash_find(STACKDRIVER_DEBUGGER_G(snapshots_by_file), filename);
-    zval *logpoints = zend_hash_find(STACKDRIVER_DEBUGGER_G(logpoints_by_file), filename);
+    zval *snapshots = NULL;
+	if (STACKDRIVER_DEBUGGER_G(snapshots_by_file) != NULL) {
+	    snapshots = zend_hash_find(STACKDRIVER_DEBUGGER_G(snapshots_by_file), filename);
+	}
+    zval *logpoints = NULL;
+	if (STACKDRIVER_DEBUGGER_G(logpoints_by_file) != NULL) {
+	    logpoints = zend_hash_find(STACKDRIVER_DEBUGGER_G(logpoints_by_file), filename);
+	}
 
     if (snapshots != NULL || logpoints != NULL) {
         reset_registered_breakpoints_for_filename(filename);


### PR DESCRIPTION
Depending on the order of initialisation, it can happen that an extension tries to compile a file before our rinit function has been called. This means that the snapshot and logpoint hashes will not have been initialised and our extension will crash. This PR adds a check so that if that happens our extension will not crash